### PR TITLE
Router improvements

### DIFF
--- a/components/router/README.md
+++ b/components/router/README.md
@@ -21,6 +21,21 @@ The router component comes with UMD and CJS builds.
 <script src="./node_modules/gameface-router/umd/router.production.min.js"></script>
 ~~~~
 
+If you import the router using a script tag - a global variable *router* will be available.
+You can access the Router, Route, BrowserHistory from it:
+
+~~~~{.js}
+const browserHistory = new router.BrowserHistory();
+router.Route.use(browserHistory);
+
+new router.Router({
+    '/': 'home-page',
+    '/start-game': '<div>Start Game</div>',
+    '/heroes': '<div>Heroes Page</div>',
+    '**': '<div>404</div>'
+}, browserHistory);
+~~~~
+
 If you wish to import the modules using JavaScript you can remove the script tags
 which import the components and the gameface-router from the node_modules folder and import them like this:
 
@@ -107,13 +122,20 @@ The `<gameface-route>` also depends on the history. To initialize it do:
 Route.use(myBrowserHistory);
 ~~~~
 
-The router is configured using an object of { 'route': 'component-name' } pairs:
+The router is configured using an object of { 'route': 'component-name | HTML' } pairs:
 
 ~~~~{.js}
 const config = {
     '/': 'home-page',
     '/start-game': 'start-game-page',
     '/heroes': 'heroes-page',
+};
+
+You can also directly put the HTML that you want to be displayed:
+
+const config = {
+    '/': '<div>Home</div>',
+    '/start-game': '<button>Start Game<button>',
 };
 
 const router = new Router(config, browserHistory);

--- a/components/router/router.js
+++ b/components/router/router.js
@@ -116,7 +116,14 @@ class Router {
         // get the <router-view> element and replace its content with the
         // new component
         const view = document.querySelector('router-view');
-        const el = document.createElement(component);
+
+        let el;
+        if (components.definedElements[component]) {
+            el = document.createElement(component);
+        } else {
+            el = document.createElement('div');
+            el.innerHTML = component
+        }
         // inject the params to the el
         // el is a custom element
         el.params = params;

--- a/components/router/router.js
+++ b/components/router/router.js
@@ -122,7 +122,7 @@ class Router {
             el = document.createElement(component);
         } else {
             el = document.createElement('div');
-            el.innerHTML = component
+            el.innerHTML = component;
         }
         // inject the params to the el
         // el is a custom element

--- a/components/router/script.js
+++ b/components/router/script.js
@@ -7,4 +7,4 @@ import { Router } from './router';
 import { Route } from './route';
 import { BrowserHistory } from './history';
 
-export { Router, Route, BrowserHistory }
+export { Router, Route, BrowserHistory };

--- a/tools/tests/router/test.js
+++ b/tools/tests/router/test.js
@@ -12,6 +12,7 @@ const NumbersModel = {
 
 const template = `<div>
 <gameface-route id="home" to="/">Home</gameface-route>
+<gameface-route id="documentation" to="/documentation">Documentation</gameface-route>
 <gameface-route id="numbers" to="/numbers">Numbers</gameface-route>
 <gameface-route id="vowel" to="/letters/vowel">Vowels</gameface-route>
 <gameface-route id="consonant" to="/letters/consonant">Consonant</gameface-route>
@@ -170,6 +171,7 @@ function setupPage() {
     let router = new Router({
         '/': 'home-page',
         '/numbers': 'numbers-page',
+        '/documentation': '<div class="documentation">Documentation<div>',
         '/numbers/:type': 'number-page',
         '/letters/:type': lettersRouter,
         '**': 'not-found-page'
@@ -242,6 +244,13 @@ describe('Router Component', () => {
         click(document.getElementById("home"));
         return createAsyncSpec(() => {
             assert(document.querySelector(routeIdToPageMap['home']) !== null, `Current page is not "home".`);
+        });
+    });
+
+    it('Should show documentation page that is not a component', async () => {
+        click(document.getElementById("documentation"));
+        return createAsyncSpec(() => {
+            assert(document.querySelector('.documentation')!== null, `Current page is not "documentation".`);
         });
     });
 
@@ -337,6 +346,6 @@ describe('Router Component', () => {
         return createAsyncSpec(() => {
             assert(history.state.current === '/wrongpath', 'Current history state is not "/wrongpath".');
             assert(document.querySelector('router-view').textContent === `Can't find this page.`, 'Current page "/wrongpath" content is not correct; perhaps it failed to render.');
-        })
+        });
     });
 });


### PR DESCRIPTION
Allow the router to render plain HTML.
Document the new behavior.
Explain how to use as global with umd.
Add test.

Note: router.Router is confusing, but we export { Router, Route, BrowserHistory } and rollup wraps them in a umd using a variable - in this case react (we can rename it). React-router also exports ReactRouter.MemoryRouter etc.. - https://unpkg.com/browse/react-router@5.2.0/umd/react-router.js