### PR TITLE
Local packages workflow

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -26,5 +26,5 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm i
-    - run: npm run rebuild
+    - run: npm run build:dev
     - run: npm test -- --browsers Chrome

--- a/README.md
+++ b/README.md
@@ -79,15 +79,29 @@ To build and package everything run:
 
 `npm run rebuild`
 
-To start the tests run:
-
-`npm run test`
-
 If you haven't built the components or if you've made changes:
 
 `npm run test -- --rebuild`
 
 to create new bundles.
+
+To build the components using **only** the local packages run:
+
+`npm run build:dev`
+
+This will make links between all components allowing you to test with your local
+changes.
+
+To create links without building run:
+
+`npm run link`
+
+Make sure to run the `build` command with the **--no-install** or **-ni** option to avoid
+executing `npm i` which will overwrite your links.
+
+To start the tests run:
+
+`npm run test`
 
 After you successfully execute `npm run tests` open the Gameface player or Chrome with "--url=http://localhost:9876/debug.html" to see the tests running.
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,41 @@ You can use [http-server](https://www.npmjs.com/package/http-server) or any http
 
 
 
+Available Commands
+===================
+
+These are the commands used to build and package the components.
+
+|Command   |Description   |Arguments   |Usage   |
+|---|---|---|---|
+|rebuild               |Do a clean install of all dependencies and build everything.                 |N/A|`npm run rebuild`|
+|build                 |Build all components - create their demo, umd and cjs bundles.               |[--no-install -ni][--no-install], [--library][--library], [ --documentation][ --documentation]|`npm run build -- --no-install --library --documentation`|
+|build:demo            |Build only the demos of all components.                                      |N/A|`npm run build:demo`|
+|build:library         |Build only the components library.                                           |N/A|`npm run build:library`|
+|build:dev             |Build the components using only the local packages. Will install dependencies only from source, not the npm registry. |N/A|`npm run build:dev`|
+|build:documentation   |Build the components, the demos and the documentation.                       |N/A|`npm run build:documentation`|
+|start:demo            |Serve the demo project.                                                      |N/A|`npm run start:demo`|
+|test                  |Start Karma server on loalhost:<port>/debug.html                             |N/A|`npm run test`|
+|test:Chrome           |Start Karma server and run the tests in Google Chrome.                       |N/A|`npm run test:Chrome`|
+|pack                  |Bundle the components tp npm packages ready for publish.                     |N/A|`npm run pack`|
+|pack:library          |Create npm package of the component library.                                 |N/A|`npm run pack:library`|
+|link                  |Create links for all components to test with local packages only[^1].        |N/A|`npm run link`|
+|install:all           |Recursively Install dependencies in all folders located in given root.       |[--rootDir][--rootDir]|`npm run install:all -- --rootDir=components/checkbox`|
+|clean                 |Remove all existing bundles, packages and installed dependencies.            |N/A|`npm run clean`|
+
+[^1]: The components will not use the local packages created from source, not the ones from the npm
+registry. Useful when you are doing changes the core library or to any of the existing components
+and you want to test your changes. Remember to build with the **--no-install** option when using links
+as otherwise the build will perform `npm install` which will overwrite the links.
+
+[--no-install]: ## "skip the npm install step"
+[--library]: ## "builds only the components library"
+[--documentation]: ## "also build the documentation"
+[--rootDir]: ## "the folder in which to perform recursive npm install"
+
+After you successfully execute `npm run tests` open the Gameface player or Chrome with "--url=http://localhost:9876/debug.html" to see the tests running.
+
+
 Creating new Components
 ===================
 
@@ -44,66 +79,6 @@ All components are npm modules. Your component doesn't have to be an npm module.
 If you need to use it in your project only, you can skip the steps which make a
 component an npm module. However if at some point you decide that you want to make
 your component an npm module - follow the steps below to see how to do it.
-
-These are the commands used to build and package the components.
-
-To build all components run:
-
-`npm run build`
-
-This will create bundles with ready to use CJS and UMD modules.
-
-
-To build the demo pages only run:
-
-`npm run build:demo`
-
-To clean all build and installation files run:
-
-`npm run clean`
-
-To build the components and update the documentation files:
-
-`npm run build:documentation` or
-`npm run build -- --documentation`
-
-To create the npm packages run:
-
-`npm run pack`
-
-To package the components library only run:
-
-`npm run pack:library`
-
-To build and package everything run:
-
-`npm run rebuild`
-
-If you haven't built the components or if you've made changes:
-
-`npm run test -- --rebuild`
-
-to create new bundles.
-
-To build the components using **only** the local packages run:
-
-`npm run build:dev`
-
-This will make links between all components allowing you to test with your local
-changes.
-
-To create links without building run:
-
-`npm run link`
-
-Make sure to run the `build` command with the **--no-install** or **-ni** option to avoid
-executing `npm i` which will overwrite your links.
-
-To start the tests run:
-
-`npm run test`
-
-After you successfully execute `npm run tests` open the Gameface player or Chrome with "--url=http://localhost:9876/debug.html" to see the tests running.
 
 ## Structure of a Component
 All components in the GameUIComponents suite are npm modules.

--- a/README.md
+++ b/README.md
@@ -51,12 +51,13 @@ These are the commands used to build and package the components.
 |build:dev             |Build the components using only the local packages. Will install dependencies only from source, not the npm registry. |N/A|`npm run build:dev`|
 |build:documentation   |Build the components, the demos and the documentation.                       |N/A|`npm run build:documentation`|
 |start:demo            |Serve the demo project.                                                      |N/A|`npm run start:demo`|
-|test                  |Start Karma server on loalhost:<port>/debug.html                             |N/A|`npm run test`|
+|test                  |Start Karma server on localhost:`<port>`/debug.html                             |N/A|`npm run test`|
 |test:Chrome           |Start Karma server and run the tests in Google Chrome.                       |N/A|`npm run test:Chrome`|
-|pack                  |Bundle the components tp npm packages ready for publish.                     |N/A|`npm run pack`|
+|pack                  |Bundle the components to npm packages ready for publish.                     |N/A|`npm run pack`|
 |pack:library          |Create npm package of the component library.                                 |N/A|`npm run pack:library`|
 |link                  |Create links for all components to test with local packages only[^1].        |N/A|`npm run link`|
-|install:all           |Recursively Install dependencies in all folders located in given root.       |[--rootDir][--rootDir]|`npm run install:all -- --rootDir=components/checkbox`|
+|unlink                |Remove all global links that exist for components. To remove the local packages use `npm run clean`.|N/A|`npm run link`|
+|install:all           |Recursively install dependencies in all folders located in given root.       |[--rootDir][--rootDir]|`npm run install:all -- --rootDir=components/checkbox`|
 |clean                 |Remove all existing bundles, packages and installed dependencies.            |N/A|`npm run clean`|
 
 [^1]: The components will not use the local packages created from source, not the ones from the npm

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "start:demo": "webpack-dev-server",
     "build": "node ./scripts/build.js",
     "link": "node ./scripts/link.js",
+    "unlink": "node ./scripts/unlink.js",
     "build:dev": "npm run clean && npm run link && npm run build -- -ni",
     "build:library": "node ./scripts/build.js --library",
     "build:documentation": "node ./scripts/build.js --documentation",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   "scripts": {
     "start:demo": "webpack-dev-server",
     "build": "node ./scripts/build.js",
+    "link": "node ./scripts/link.js",
+    "build:dev": "npm run clean && npm run link && npm run build -- -ni",
     "build:library": "node ./scripts/build.js --library",
     "build:documentation": "node ./scripts/build.js --documentation",
     "clean": "node ./scripts/clean.js",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -14,6 +14,8 @@ const buildCssComponents = require('./build-style-component');
 const copyCSSTheme = require('./copy-theme');
 
 const { execSync } = require('child_process');
+
+let noInstall = false;
 // The module formats which will be bundled
 const FORMATS = [
     'cjs',
@@ -89,6 +91,14 @@ async function buildAndPackage(moduleName, inputOptions, formats, environments, 
     execSync('npm pack', { cwd: libPath });
 }
 
+function installDependencies(componentPath) {
+    try {
+      execSync('npm i', { cwd: componentPath });
+    } catch (err) {
+        console.error(err)
+    }
+}
+
 /**
  * Calls buildAndPackage for all components and passes all environments
  * and formats as targets. Builds the components library first.
@@ -108,11 +118,7 @@ async function buildEverything() {
 
         if (!fs.existsSync(componentPath)) continue;
 
-        try {
-            execSync('npm i', { cwd: componentPath });
-        } catch (err) {
-            console.error(err)
-        }
+        if(!noInstall) installDependencies(componentPath);
 
         if (!fs.existsSync(path.join(componentPath, 'script.js'))) {
             buildCssComponents(componentPath);
@@ -164,6 +170,7 @@ function createBundle(inputOptions, outputOptions) {
 async function main() {
     copyCSSTheme();
     const arguments = process.argv.slice(2);
+    if (arguments.indexOf('--no-install') > -1 || arguments.indexOf('-ni') > -1) noInstall = true;
 
     if(arguments.indexOf('--library') > -1) {
         buildComponentsLibrary();

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -1,0 +1,18 @@
+const path = require('path');
+const fs = require('fs');
+
+const COMPONENTS_PATH = path.join(__dirname, '../components');
+
+function getPackageJSON(component) {
+    const packageJSONPath = path.join(COMPONENTS_PATH, component, 'package.json');
+    const fsStats = fs.lstatSync(packageJSONPath, {throwIfNoEntry: false});
+    if (!fsStats || !fsStats.isFile()) {
+        console.error(`Could not find package.json for ${component}. Make sure the component exists and has a valid source code.`);
+        return null;
+    }
+    return JSON.parse(fs.readFileSync(packageJSONPath));
+}
+
+module.exports = {
+    getPackageJSON: getPackageJSON
+};

--- a/scripts/link.js
+++ b/scripts/link.js
@@ -1,18 +1,13 @@
 const path = require('path');
 const fs = require('fs');
 const { execSync } = require('child_process');
+const { getPackageJSON } = require('./helpers');
 
 const COMPONENTS_PATH = path.join(__dirname, '../components');
 
-function getPackageJSON(component) {
-    const packageJSONPath = path.join(COMPONENTS_PATH, component, 'package.json');
-    if (!fs.lstatSync(packageJSONPath).isFile()) return null;
-    return JSON.parse(fs.readFileSync(packageJSONPath));
-}
-
 function main() {
     // link the components library
-    execSync('npm link', { cwd: path.join(__dirname, '../lib') });
+    execSync('npm link', { cwd: path.join(__dirname, '../lib'), encoding: 'utf8' });
     const components = fs.readdirSync(COMPONENTS_PATH);
 
     // loop all components once to create links to the global node_modules.
@@ -22,13 +17,10 @@ function main() {
     // and error prone. NPM works like this, but we have an advantage in knowing the list
     // of all dependencies beforehand - everything in the /components folder and the /lib folder.
     for (let component of components) {
-        const links = execSync('npm ls -g --depth=0 --link=true', {encoding: 'utf8'});
         const packageJSON = getPackageJSON(component);
 
         if (!packageJSON) continue;
-        if (links.match(`${packageJSON.name}`)) continue;
-
-        execSync('npm link', { cwd: path.join(COMPONENTS_PATH, component) });
+        execSync('npm link', { cwd: path.join(COMPONENTS_PATH, component), encoding: 'utf8' });
     }
 
     // loop all components to link their local dependencies to the global
@@ -39,12 +31,12 @@ function main() {
 
         let componentsDeps = '';
         const dependencies = Object.keys(packageJSON.dependencies);
-        for( let dependency of dependencies) {
+        for(let dependency of dependencies) {
             if (!dependency.match(/(coherent)/g)) continue;
             componentsDeps += ` ${dependency}`;
         }
 
-        execSync(`npm link ${componentsDeps}`, { cwd: path.join(COMPONENTS_PATH, component)});
+        execSync(`npm link ${componentsDeps}`, { cwd: path.join(COMPONENTS_PATH, component), encoding: 'utf8'});
     }
 }
 

--- a/scripts/link.js
+++ b/scripts/link.js
@@ -1,0 +1,40 @@
+const path = require('path');
+const fs = require('fs');
+const { execSync, exec } = require('child_process');
+
+const COMPONENTS_PATH = path.join(__dirname, '../components');
+
+function main() {
+    const arguments = process.argv.slice(2);
+    if (arguments.indexOf('--no-build') === -1) execSync('npm run rebuild', { cwd: path.join(__dirname, '../') });
+
+    execSync('npm link', { cwd: path.join(__dirname, '../lib') });
+    const components = fs.readdirSync(COMPONENTS_PATH);
+    for (let component of components) {
+        const links = execSync('npm ls -g --depth=0 --link=true', {encoding: 'utf8'});
+
+        const packageJSONPath = path.join(COMPONENTS_PATH, component, 'package.json');
+        if (!fs.lstatSync(packageJSONPath).isFile()) constinue;
+        const packageJSON = JSON.parse(fs.readFileSync(packageJSONPath));
+        if (links.match(`${packageJSON.name}`)) continue;
+        execSync('npm link', { cwd: path.join(COMPONENTS_PATH, component) });
+    }
+
+    for (let component of components) {
+        const packageJSONPath = path.join(COMPONENTS_PATH, component, 'package.json');
+        if (!fs.lstatSync(packageJSONPath).isFile()) continue;
+
+        const packageJSON = JSON.parse(fs.readFileSync(packageJSONPath));
+        if (!packageJSON.dependencies) continue;
+
+        let componentsDeps = '';
+        for( let dependency of Object.keys(packageJSON.dependencies)) {
+            if (!dependency.match(/(coherent)/g)) continue;
+            componentsDeps += ` ${dependency}`;
+        }
+
+        execSync(`npm link ${componentsDeps}`, { cwd: path.join(COMPONENTS_PATH, component)});
+    }
+}
+
+main();

--- a/scripts/link.js
+++ b/scripts/link.js
@@ -5,9 +5,23 @@ const { getPackageJSON } = require('./helpers');
 
 const COMPONENTS_PATH = path.join(__dirname, '../components');
 
+function safelyCreateLink(cwd, component, packages = '') {
+    const linked = packages || component;
+    try {
+        execSync(`npm link ${packages}`, { cwd: cwd, encoding: 'utf8'});
+        if (packages) {
+            console.log(`Linked dependencies - ${packages.replace(/\s/g, ', ')} for component ${component}.`);
+        } else {
+            console.log(`Created link for ${component}.`);
+        }
+    } catch (err) {
+        console.error(`The following error ocurred while linking ${linked}: ${err}`);
+    }
+}
+
 function main() {
     // link the components library
-    execSync('npm link', { cwd: path.join(__dirname, '../lib'), encoding: 'utf8' });
+    safelyCreateLink(path.join(__dirname, '../lib'), 'coherent-gameface-components');
     const components = fs.readdirSync(COMPONENTS_PATH);
 
     // loop all components once to create links to the global node_modules.
@@ -20,7 +34,7 @@ function main() {
         const packageJSON = getPackageJSON(component);
 
         if (!packageJSON) continue;
-        execSync('npm link', { cwd: path.join(COMPONENTS_PATH, component), encoding: 'utf8' });
+        safelyCreateLink(path.join(COMPONENTS_PATH, component), component);
     }
 
     // loop all components to link their local dependencies to the global
@@ -36,7 +50,7 @@ function main() {
             componentsDeps += ` ${dependency}`;
         }
 
-        execSync(`npm link ${componentsDeps}`, { cwd: path.join(COMPONENTS_PATH, component), encoding: 'utf8'});
+        safelyCreateLink(path.join(COMPONENTS_PATH, component), component, componentsDeps.trim())
     }
 }
 

--- a/scripts/link.js
+++ b/scripts/link.js
@@ -11,9 +11,6 @@ function getPackageJSON(component) {
 }
 
 function main() {
-    const arguments = process.argv.slice(2);
-    if (arguments.indexOf('--no-build') === -1) execSync('npm run rebuild', { cwd: path.join(__dirname, '../') });
-
     // link the components library
     execSync('npm link', { cwd: path.join(__dirname, '../lib') });
     const components = fs.readdirSync(COMPONENTS_PATH);

--- a/scripts/link.js
+++ b/scripts/link.js
@@ -1,34 +1,48 @@
 const path = require('path');
 const fs = require('fs');
-const { execSync, exec } = require('child_process');
+const { execSync } = require('child_process');
 
 const COMPONENTS_PATH = path.join(__dirname, '../components');
+
+function getPackageJSON(component) {
+    const packageJSONPath = path.join(COMPONENTS_PATH, component, 'package.json');
+    if (!fs.lstatSync(packageJSONPath).isFile()) return null;
+    return JSON.parse(fs.readFileSync(packageJSONPath));
+}
 
 function main() {
     const arguments = process.argv.slice(2);
     if (arguments.indexOf('--no-build') === -1) execSync('npm run rebuild', { cwd: path.join(__dirname, '../') });
 
+    // link the components library
     execSync('npm link', { cwd: path.join(__dirname, '../lib') });
     const components = fs.readdirSync(COMPONENTS_PATH);
+
+    // loop all components once to create links to the global node_modules.
+    // This is needed because later we'll link a component's local dependencies
+    // to the global node modules and we need to make sure all components already have links;
+    // otherwise we would have to recursively go through all dependencies, which is slow
+    // and error prone. NPM works like this, but we have an advantage in knowing the list
+    // of all dependencies beforehand - everything in the /components folder and the /lib folder.
     for (let component of components) {
         const links = execSync('npm ls -g --depth=0 --link=true', {encoding: 'utf8'});
+        const packageJSON = getPackageJSON(component);
 
-        const packageJSONPath = path.join(COMPONENTS_PATH, component, 'package.json');
-        if (!fs.lstatSync(packageJSONPath).isFile()) constinue;
-        const packageJSON = JSON.parse(fs.readFileSync(packageJSONPath));
+        if (!packageJSON) continue;
         if (links.match(`${packageJSON.name}`)) continue;
+
         execSync('npm link', { cwd: path.join(COMPONENTS_PATH, component) });
     }
 
+    // loop all components to link their local dependencies to the global
+    // dependencies that we linked in the previous loop.
     for (let component of components) {
-        const packageJSONPath = path.join(COMPONENTS_PATH, component, 'package.json');
-        if (!fs.lstatSync(packageJSONPath).isFile()) continue;
-
-        const packageJSON = JSON.parse(fs.readFileSync(packageJSONPath));
-        if (!packageJSON.dependencies) continue;
+        const packageJSON = getPackageJSON(component);
+        if (!packageJSON || !packageJSON.dependencies) continue;
 
         let componentsDeps = '';
-        for( let dependency of Object.keys(packageJSON.dependencies)) {
+        const dependencies = Object.keys(packageJSON.dependencies);
+        for( let dependency of dependencies) {
             if (!dependency.match(/(coherent)/g)) continue;
             componentsDeps += ` ${dependency}`;
         }

--- a/scripts/unlink.js
+++ b/scripts/unlink.js
@@ -1,0 +1,28 @@
+const path = require('path');
+const fs = require('fs');
+const { execSync } = require('child_process');
+const { getPackageJSON } = require('./helpers');
+
+const COMPONENTS_PATH = path.join(__dirname, '../components');
+
+function main() {
+    console.log('Removing links...')
+    execSync('npm unlink -g', { cwd: path.join(__dirname, '../lib'), encoding: 'utf8' });
+    const components = fs.readdirSync(COMPONENTS_PATH);
+
+    const removedPackages = [];
+    for (let component of components) {
+        const packageJSON = getPackageJSON(component);
+
+        if (!packageJSON) continue;
+        const result = execSync('npm unlink -g', { cwd: path.join(COMPONENTS_PATH, component), encoding: 'utf8' });
+        // The result from npm has to many new lines, remove the ones at the start and end of the string and
+        // replace one that's in the middle with a comma
+        console.log(`${result.replace(/^\n|\n$/g, '').replace(/\n/, ', ')}(${packageJSON.name})\n`);
+        removedPackages.push(packageJSON.name);
+    }
+
+    console.log(`Unlinked ${removedPackages.length} packages:\n${removedPackages.join('\n')}`);
+}
+
+main();

--- a/tools/cli/commands/build-demo.js
+++ b/tools/cli/commands/build-demo.js
@@ -12,6 +12,8 @@ const { start } = require('repl');
 /**
  * Builds the demo of the component.
 */
+
+
 function buildDemo() {
     const pathToDemo = path.resolve(path.join(process.cwd(), 'demo'));
 
@@ -19,6 +21,9 @@ function buildDemo() {
         mode: 'production',
         entry: path.join(pathToDemo, 'demo.js'),
         devtool: false,
+        resolve: {
+            symlinks: true,
+        },
         output: {
             path: pathToDemo,
             filename: "bundle.js"

--- a/tools/cli/commands/build.js
+++ b/tools/cli/commands/build.js
@@ -81,6 +81,7 @@ function buildForTargets(moduleName, inputOptions, formats, environments) {
 */
 function build(watch) {
     const inputOptions = {
+        preserveSymlinks: true,
         input: path.resolve('./script.js'),
         external: ['coherent-gameface-components'],
         plugins: [


### PR DESCRIPTION
Added a script that creates a link for all components so that we can use the local packages created from source, not the ones published to the npm regigstry.

We loop the components twice because:

1. First we need to make links for all components which will make them public node_modules
2. Then we need to link the local dependencies of each component to point to the public modules we linked in step 1

Tried to figure a smarter way:

1. Similar to npm to read the package.json of the component  and link its dependencies first, this meant that we would have to go recursively up each dependency and dependency of dependency....
2. We also had to figure the name of the folder of the component from the name of its package. For example the checkbox has dependency gameface-cimponents. In order to link it we need to run `npm link` in the lib/ folder and after that run `link gameface-components` in the checkbox folder. There's no way to figure the folder, as the names are not consistent nor they follow any convention like in npm ( we didn't think we would need it, so we named them as we felt was appropriate). I tried to create a map (a global constant) that holds <package_name>: <folder_name> paris, but the problem with the recursive dependencies still remained, so I chose the simplest solution - to loop the components twice.  And we skip a component if a **global** link already exists. 


The expected workflow is to make the links **once** and only call build after that, so performance is not crucial requirement. 


Also added the table that describes all commands and adjusted some commands to works as they are described in the  documentation.