### PR TITLE
Remove Tests timers

### DIFF
--- a/tools/tests/actions.js
+++ b/tools/tests/actions.js
@@ -3,6 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+const DEFAULT_FRAMES_TO_WAIT = 3;
+
 /**
  * Replacement of HtmlElement.click.
  * Dispatches a custom event of type click on a given target element
@@ -20,8 +22,24 @@ function click(element, customEventInit = {}) {
  * @param {number} count - the amount of frames that the callback execution
  * should be delayed by.
 */
-function waitForStyles(callback = () => { }, count = 3) {
+function waitForStyles(callback = () => {}, count = DEFAULT_FRAMES_TO_WAIT) {
     if (count === 0) return callback();
     count--;
     requestAnimationFrame(() => waitForStyles(callback, count));
+}
+
+/**
+ * Usually wraps assert() in cases where there is a need to wait before validating
+ * or wraps an action which needs some frames before proceeding to a validation with assert().
+ * @param {Function} callback
+ * @param {number} frames
+ * @returns {Promise}
+ */
+function createAsyncSpec(callback = () => {}, frames = DEFAULT_FRAMES_TO_WAIT) {
+    return new Promise(resolve => {
+        waitForStyles(() => {
+            callback();
+            resolve();
+        }, frames);
+    });
 }

--- a/tools/tests/automatic-grid/test.js
+++ b/tools/tests/automatic-grid/test.js
@@ -15,7 +15,7 @@ const loadGrid = () => {
     document.body.appendChild(wrapper.children[0]);
 
     return new Promise((resolve) => {
-        setTimeout(() => resolve(), 1000);
+        waitForStyles(resolve);
     });
 };
 

--- a/tools/tests/checkbox/test.js
+++ b/tools/tests/checkbox/test.js
@@ -27,13 +27,13 @@ describe('Checkbox component', () => {
         const el = document.createElement('gameface-checkbox');
         document.body.appendChild(el);
 
-        setTimeout(() => {
+        waitForStyles(() => {
             done();
-        }, 1000);
+        });
     });
 
     it('Should be rendered', () => {
-        assert(document.querySelector('gameface-checkbox') !== 'null', 'Checkbox was not rendered.');
+        assert(document.querySelector('gameface-checkbox') !== null, 'Checkbox was not rendered.');
     });
 
     it('Should toggle state when it\'s clicked', () => {

--- a/tools/tests/dropdown/multiple-dropdown.test.js
+++ b/tools/tests/dropdown/multiple-dropdown.test.js
@@ -32,18 +32,9 @@ function setupMultipleDropdownTestPage(template) {
     document.body.appendChild(el);
 
     return new Promise(resolve => {
-        setTimeout(() => {
-            resolve();
-        }, 1000);
+        waitForStyles(resolve);
     });
 }
-
-function dispatchKeyboardEvent(keyCode, element) {
-    element.dispatchEvent(new KeyboardEvent('keydown', { keyCode: keyCode }));
-}
-
-const expectedValues = ['Cat', 'Parrot', 'Parrot1'];
-const expectedValuesAfterDeselect = ['Cat', 'Parrot'];
 
 
 describe('Multiple Dropdown Test', () => {
@@ -60,9 +51,12 @@ describe('Multiple Dropdown Test', () => {
             setupMultipleDropdownTestPage(multipleDropdownTemplate).then(done).catch(err => console.error(err));
         });
 
-        it('Should have its options list expanded', () => {
-            assert(document.querySelector('.options-container').classList.contains('hidden') === false,
-                'Options container is not hidden.');
+        it('Should have its options list expanded', async () => {
+            // Wait 6 frames because the multiple (and not collapsable) dropdown opens after 6 frames.
+            return createAsyncSpec(() => {
+                assert(document.querySelector('.options-container').classList.contains('hidden') === false,
+                  'Options container is hidden.');
+            }, 6);
         });
 
         it('Should select multiple elements', () => {
@@ -75,12 +69,6 @@ describe('Multiple Dropdown Test', () => {
 
             assert(dropdown.selectedOptions.length === 3,
                 `Expected selected options length to be 3, got ${dropdown.selectedOptions.length}.`);
-        });
-    });
-
-    describe('Multiple Dropdown Component', () => {
-        beforeEach(function (done) {
-            setupMultipleDropdownTestPage(multipleDropdownTemplate).then(done).catch(err => console.error(err));
         });
 
         it('Should deselect multiple elements', () => {
@@ -95,13 +83,7 @@ describe('Multiple Dropdown Test', () => {
             options[2].onClick({ target: options[2], ctrlKey: true });
 
             assert(dropdown.selectedOptions.length === 1,
-                `It didn't select only one element. Expected selected options length to be 1, got ${dropdown.selectedOptions.length}.`);
-        });
-    });
-
-    describe('Multiple Dropdown Component', () => {
-        beforeEach(function (done) {
-            setupMultipleDropdownTestPage(multipleDropdownTemplate).then(done).catch(err => console.error(err));
+              `It didn't select only one element. Expected selected options length to be 1, got ${dropdown.selectedOptions.length}.`);
         });
 
         it('Should select multiple elements and then select 1', () => {
@@ -115,7 +97,7 @@ describe('Multiple Dropdown Test', () => {
             options[0].onClick({ target: options[0] });
 
             assert(dropdown.selectedOptions.length === 1,
-                `It didn't select only one element. Expected selected options length to be 1, got ${dropdown.selectedOptions.length}.`);
+              `It didn't select only one element. Expected selected options length to be 1, got ${dropdown.selectedOptions.length}.`);
         });
     });
 

--- a/tools/tests/dropdown/test.js
+++ b/tools/tests/dropdown/test.js
@@ -91,9 +91,7 @@ function setupDropdownTestPage() {
     document.body.appendChild(el);
 
     return new Promise(resolve => {
-        setTimeout(() => {
-            resolve();
-        }, 1000);
+        waitForStyles(resolve);
     });
 }
 
@@ -101,15 +99,6 @@ const firstValue = 'Cat';
 const secondValue = 'Dog';
 const changedValue = 'Giraffe';
 const lastValue = 'Last Parrot';
-
-function createDropdownAsyncSpec(callback, time = 1000) {
-    return new Promise(resolve => {
-        setTimeout(() => {
-            callback();
-            resolve();
-        }, time);
-    });
-}
 
 const KEY_CODES = {
     'ARROW_UP': 38,
@@ -154,35 +143,24 @@ describe('Dropdown Tests', () => {
             const dropdown = document.querySelector('gameface-dropdown');
             assert(dropdown.querySelector('.selected').textContent === firstValue, 'Selected value is not the first value.');
         });
-    });
-
-
-    describe('Dropdown Component', () => {
-        beforeEach(function (done) {
-            setupDropdownTestPage().then(done).catch(err => console.error(err));
-        });
 
         it('Should toggle the options list on click', async () => {
             const dropdown = document.querySelector('gameface-dropdown');
             const selectedElPlaceholder = dropdown.querySelector('.selected');
 
             click(selectedElPlaceholder);
-            await createDropdownAsyncSpec(() => {
+
+            await createAsyncSpec(() => {
                 assert(dropdown.querySelector('.options-container').classList.contains('hidden') === false, 'Dropdown has class hidden.');
             });
 
             click(selectedElPlaceholder);
-            return createDropdownAsyncSpec(() => {
+
+            return createAsyncSpec(() => {
                 assert(dropdown.querySelector('.options-container').classList.contains('hidden') === true, 'Dropdown does not have class hidden.');
             });
         });
-    });
 
-
-    describe('Dropdown Component', () => {
-        beforeEach(function(done) {
-            setupDropdownTestPage().then(done).catch(err => console.error(err));
-        });
         it('Should change the selected option on click', async () => {
             const dropdown = document.querySelector('gameface-dropdown');
             const selectedElPlaceholder = dropdown.querySelector('.selected');
@@ -191,75 +169,56 @@ describe('Dropdown Tests', () => {
 
             const option = dropdown.allOptions[2];
             click(option);
-            return createDropdownAsyncSpec(() => {
+
+            return createAsyncSpec(() => {
                 assert(dropdown.querySelector('.selected').textContent === changedValue, `Changed value is not ${changedValue}`);
             });
-        });
-    });
-
-
-    describe('Dropdown Component', () => {
-        beforeEach(function (done) {
-            setupDropdownTestPage().then(done).catch(err => console.error(err));
         });
 
         it('Should select using keyboard ARROW_DOWN and ARROW_UP keys', async () => {
             const dropdown = document.querySelector('gameface-dropdown');
             const selectedElPlaceholder = dropdown.querySelector('.selected');
 
-            await createDropdownAsyncSpec(() => {
+            await createAsyncSpec(() => {
                 click(selectedElPlaceholder);
             });
 
-            await createDropdownAsyncSpec(() => {
+            await createAsyncSpec(() => {
                 dispatchKeyboardEvent(KEY_CODES.ARROW_DOWN, dropdown);
             });
 
-            await createDropdownAsyncSpec(() => {
+            await createAsyncSpec(() => {
                 assert(dropdown.value === secondValue, `Dropdown value is not ${secondValue}`);
             });
 
             dispatchKeyboardEvent(KEY_CODES.ARROW_UP, dropdown);
 
-            return createDropdownAsyncSpec(() => {
+            return createAsyncSpec(() => {
                 assert(dropdown.value === firstValue, `Dropdown value is not ${firstValue}`);
             });
-        });
-    });
-
-
-    describe('Dropdown Component', () => {
-        beforeEach(function(done) {
-            setupDropdownTestPage().then(done).catch(err => console.error(err));
         });
 
         it('Should select using keyboard ARROW_RIGHT and ARROW_LEFT keys', async () => {
             const dropdown = document.querySelector('gameface-dropdown');
             const selectedElPlaceholder = dropdown.querySelector('.selected');
 
-            await createDropdownAsyncSpec(() => {
+            await createAsyncSpec(() => {
                 click(selectedElPlaceholder);
             });
 
-            await createDropdownAsyncSpec(() => {
+            await createAsyncSpec(() => {
                 dispatchKeyboardEvent(KEY_CODES.ARROW_RIGHT, dropdown);
             });
 
-            await createDropdownAsyncSpec(() => {
+            await createAsyncSpec(() => {
                 assert(dropdown.value === secondValue, `Dropdown value is not ${secondValue}`);
             });
 
             dispatchKeyboardEvent(KEY_CODES.ARROW_LEFT, dropdown);
-            return createDropdownAsyncSpec(() => {
+
+            return createAsyncSpec(() => {
                 assert(dropdown.value === firstValue, `Dropdown value is not ${firstValue}`);
             });
-        });
-    });
-
-
-    describe('Dropdown Component', () => {
-        beforeEach(function (done) {
-            setupDropdownTestPage().then(done).catch(err => console.error(err));
         });
 
         it('Should select using keyboard HOME and END keys', async () => {
@@ -281,58 +240,39 @@ describe('Dropdown Tests', () => {
 
             assert(dropdown.value === firstValue, `Dropdown value is not ${firstValue}`);
         });
-    });
-
-    describe('Dropdown Component', () => {
-        beforeEach(function (done) {
-            setupDropdownTestPage().then(done).catch(err => console.error(err));
-        });
 
         it('Should close the options list using keyboard ENTER key', async () => {
             const dropdown = document.querySelector('gameface-dropdown');
             const selectedElPlaceholder = dropdown.querySelector('.selected');
 
-            await createDropdownAsyncSpec(() => {
+            await createAsyncSpec(() => {
                 click(selectedElPlaceholder);
             });
 
-            await createDropdownAsyncSpec(() => {
+            await createAsyncSpec(() => {
                 dispatchKeyboardEvent(KEY_CODES.ENTER, dropdown);
             });
-            return createDropdownAsyncSpec(() => {
+
+            return createAsyncSpec(() => {
                 assert(dropdown.querySelector('.options-container').classList.contains('hidden') === true, 'Dropdown does not contain class hidden.');
             });
-        });
-    });
-
-
-    describe('Dropdown Component', () => {
-        beforeEach(function (done) {
-            setupDropdownTestPage().then(done).catch(err => console.error(err));
         });
 
         it('Should close the options list using keyboard ESC key', async () => {
             const dropdown = document.querySelector('gameface-dropdown');
             const selectedElPlaceholder = dropdown.querySelector('.selected');
 
-            await createDropdownAsyncSpec(() => {
+            await createAsyncSpec(() => {
                 click(selectedElPlaceholder);
             });
 
-            await createDropdownAsyncSpec(() => {
+            await createAsyncSpec(() => {
                 dispatchKeyboardEvent(KEY_CODES.ESCAPE, dropdown);
             });
 
-            return createDropdownAsyncSpec(() => {
+            return createAsyncSpec(() => {
                 assert(dropdown.querySelector('.options-container').classList.contains('hidden') === true, 'Dropdown does not contain class hidden.');
             });
-        });
-    });
-
-
-    describe('Dropdown Component', () => {
-        beforeEach(function (done) {
-            setupDropdownTestPage().then(done).catch(err => console.error(err));
         });
 
         it('Should close the options list on clicking outside of the dropdown', function (done) {
@@ -340,16 +280,10 @@ describe('Dropdown Tests', () => {
 
             click(document.querySelector('.dropdown-test-wrapper'));
 
-            createDropdownAsyncSpec(() => {
+            createAsyncSpec(() => {
                 assert(dropdown.querySelector('.options-container').classList.contains('hidden') === true, 'Dropdown does not have class hidden.');
                 done();
             });
-        });
-    });
-
-    describe('Dropdown Component', () => {
-        beforeEach(function(done) {
-            setupDropdownTestPage().then(done).catch(err => console.error(err));
         });
 
         it('Should select the next enabled option', async () => {
@@ -358,25 +292,20 @@ describe('Dropdown Tests', () => {
 
             click(selectedElPlaceholder);
 
-            await createDropdownAsyncSpec(() => {
+            await createAsyncSpec(() => {
                 const option = dropdown.allOptions[3];
                 click(option);
-            }, 100);
-            await createDropdownAsyncSpec(() => {
+            });
+
+            await createAsyncSpec(() => {
                 assert(document.querySelector('gameface-dropdown').querySelector('.selected').textContent === 'Lion', 'Dropdown value is not Lion.');
                 click(selectedElPlaceholder);
                 dispatchKeyboardEvent(KEY_CODES.ARROW_RIGHT, dropdown);
-            }, 100);
-            return createDropdownAsyncSpec(() => {
+            });
+
+            return createAsyncSpec(() => {
                 assert(document.querySelector('gameface-dropdown').value === 'Eagle', 'Dropdown value is not Eagle.');
-            }, 100);
-        });
-    });
-
-
-    describe('Dropdown Component', () => {
-        beforeEach(function(done) {
-            setupDropdownTestPage().then(done).catch(err => console.error(err));
+            });
         });
 
         it('Should select the previous enabled option', async () => {
@@ -385,16 +314,18 @@ describe('Dropdown Tests', () => {
 
             click(selectedElPlaceholder);
 
-            await createDropdownAsyncSpec(() => {
+            await createAsyncSpec(() => {
                 const option = dropdown.allOptions[5];
                 click(option);
             });
-            await createDropdownAsyncSpec(() => {
+
+            await createAsyncSpec(() => {
                 assert(document.querySelector('gameface-dropdown').querySelector('.selected').textContent === 'Eagle', 'Dropdown value is not equal to Eagle.');
                 click(selectedElPlaceholder);
                 dispatchKeyboardEvent(KEY_CODES.ARROW_LEFT, dropdown);
             });
-            await createDropdownAsyncSpec(() => {
+
+            return createAsyncSpec(() => {
                 assert(document.querySelector('gameface-dropdown').value === 'Lion', 'Dropdown value is not equal to Lion.');
             });
         });

--- a/tools/tests/lib/test.js
+++ b/tools/tests/lib/test.js
@@ -2,15 +2,6 @@
  *  Copyright (c) Coherent Labs AD. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-function createAsyncSpec(callback, time = 1000) {
-    return new Promise(resolve => {
-        setTimeout(() => {
-            callback();
-            resolve();
-        }, time);
-    });
-}
-
 
 describe('Components Library', () => {
     afterAll(() => {
@@ -220,16 +211,14 @@ describe('Components Library', () => {
 
         document.body.appendChild(testWrapper);
         return createAsyncSpec(() => {
-            waitForStyles(() => {
-                const parentElements = document.querySelectorAll('parent-el');
-                for (let i = 0; i < parentElements.length; i++) {
-                    assert(parentElements[i].timesRendered === 1, `Parent element ${parentElements[i]} was rendered more than once.`);
-                }
-                const childElements = document.querySelectorAll('child-el');
-                for (let i = 0; i < childElements.length; i++) {
-                    assert(childElements[i].timesRendered === 1, `Child element ${childElements[i]} was rendered more than once.`);
-                }
-            });
+            const parentElements = document.querySelectorAll('parent-el');
+            for (let i = 0; i < parentElements.length; i++) {
+                assert(parentElements[i].timesRendered === 1, `Parent element ${parentElements[i]} was rendered more than once.`);
+            }
+            const childElements = document.querySelectorAll('child-el');
+            for (let i = 0; i < childElements.length; i++) {
+                assert(childElements[i].timesRendered === 1, `Child element ${childElements[i]} was rendered more than once.`);
+            }
         });
     });
 });

--- a/tools/tests/menu/test.js
+++ b/tools/tests/menu/test.js
@@ -36,7 +36,7 @@ function setupMenuTestPage() {
     document.body.appendChild(el);
 
     return new Promise(resolve => {
-        setTimeout(resolve, 1000);
+        waitForStyles(resolve);
     });
 }
 
@@ -48,7 +48,6 @@ describe('Menu Component Tests', () => {
         if (currentElement) {
             currentElement.parentElement.removeChild(currentElement);
         }
-
     });
 
     describe('Menu Component', () => {
@@ -59,39 +58,22 @@ describe('Menu Component Tests', () => {
         it('Should be rendered', function () {
             assert(document.querySelectorAll('menu-item')[0].textContent === 'Start Game', 'The textContent of the menu is not Start Game');
         });
-    });
-
-
-    describe('Menu Component', () => {
-        beforeEach(function (done) {
-            setupMenuTestPage().then(done);
-        });
 
         it('Should open a nested menu', () => {
             click(document.getElementById("settings"), { bubbles: true });
             assert(document.querySelector('gameface-left-menu').style.display === 'flex', 'The display style of the menu is not flex.');
         });
-    });
-
-    describe('Menu Component', () => {
-        beforeEach(function (done) {
-            setupMenuTestPage().then(done);
-        }, 3000);
 
         it('Should select an element', () => {
             click(document.getElementById("game"), { bubbles: true });
             assert(document.getElementById("game").classList.contains('active-menu-item') === true, 'The selected menu element is does not have value = game');
         });
-    });
-
-    describe('Menu Component', () => {
-        beforeEach(function (done) {
-            setupMenuTestPage().then(done);
-        }, 3000);
 
         it('Should not select a disabled element', () => {
-            click(document.getElementById("hero_gallery"), { bubbles: true });
-            assert(document.getElementById("hero_gallery").classList.contains('active-menu-item') === false, 'Selected menu element is hero_gallery, but it should not be it.');
+            const heroGallery = document.getElementById("hero_gallery");
+
+            click(heroGallery, { bubbles: true });
+            assert(heroGallery.classList.contains('active-menu-item') === false, 'Selected menu element is hero_gallery, but it should not be it.');
         });
     });
 });

--- a/tools/tests/modal/test.js
+++ b/tools/tests/modal/test.js
@@ -19,7 +19,9 @@ describe('Modal Component', () => {
 
         document.body.appendChild(el);
 
-        setTimeout(done, 2000);
+        waitForStyles(() => {
+            done();
+        });
     });
 
     afterAll(() => {

--- a/tools/tests/progress-bar/test.js
+++ b/tools/tests/progress-bar/test.js
@@ -8,7 +8,6 @@ const animationTime = 100;
 
 const templateNoAnimation = `<gameface-progress-bar></gameface-progress-bar>`;
 
-// Async will test after 1000ms that is why the duration is set below 1000ms.
 const templateAnimation100ms = `<gameface-progress-bar data-animation-duration="${animationTime}"></gameface-progress-bar>`;
 
 function setupProgressBar(template) {
@@ -30,18 +29,7 @@ function setupProgressBar(template) {
   document.body.appendChild(el);
 
   return new Promise(resolve => {
-    setTimeout(() => {
-      resolve();
-    }, 1000);
-  });
-}
-
-function createProgressBarAsyncSpec(callback, time = 1000) {
-  return new Promise(resolve => {
-    setTimeout(() => {
-      callback();
-      resolve();
-    }, time);
+    waitForStyles(resolve);
   });
 }
 
@@ -62,33 +50,15 @@ describe('Progress Bar Tests', () => {
     it(`Should have rendered`, () => {
       assert(document.querySelector('gameface-progress-bar') !== null, `Progress Bar element is not rendered.`);
     });
-  });
-
-  describe('Progress Bar Component', () => {
-    beforeEach(function (done) {
-      setupProgressBar(templateNoAnimation).then(done).catch(err => console.error(err));
-    });
 
     it(`Should have been set to ${targetValue}% width.`, () => {
       document.querySelector('gameface-progress-bar').setProgress(targetValue);
       assert(parseInt(document.querySelector('.progress-bar-filler').style.width) === targetValue, `Progress bar has not been set to ${targetValue}% width.`);
     });
-  });
-
-  describe('Progress Bar Component', () => {
-    beforeEach(function (done) {
-      setupProgressBar(templateNoAnimation).then(done).catch(err => console.error(err));
-    });
 
     it(`Should have been set to 0% width when a value lower than 0 is passed.`, () => {
       document.querySelector('gameface-progress-bar').setProgress(-50);
       assert(parseInt(document.querySelector('.progress-bar-filler').style.width) === 0, `Progress bar has not been set to 0% width.`);
-    });
-  });
-
-  describe('Progress Bar Component', () => {
-    beforeEach(function (done) {
-      setupProgressBar(templateNoAnimation).then(done).catch(err => console.error(err));
     });
 
     it(`Should have been set to 100% width when a value higher than the maximum is passed.`, () => {
@@ -102,19 +72,18 @@ describe('Progress Bar Tests', () => {
       setupProgressBar(templateAnimation100ms).then(done).catch(err => console.error(err));
     });
 
-    it(`Should have an animation running.`, (done) => {
+    it(`Should have an animation running.`, async () => {
       const progressBarFiller = document.querySelector('.progress-bar-filler');
       let intermediateWidthValue = 0;
 
       document.querySelector('gameface-progress-bar').setProgress(targetValue);
 
       setTimeout(() => {
-        waitForStyles(() => {
+        return createAsyncSpec(() => {
           intermediateWidthValue = parseInt(progressBarFiller.style.width);
 
           assert(intermediateWidthValue > 0 && intermediateWidthValue < targetValue, `Progress bar has not started an animation.`);
-          done();
-        }, 2);
+        });
       }, animationTime / 4); // Get the value and validate while still running the animation.
     });
   });

--- a/tools/tests/radial-menu/test.js
+++ b/tools/tests/radial-menu/test.js
@@ -3,16 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-function createAsyncSpec(callback, time = 1000) {
-	return new Promise(resolve => {
-		setTimeout(() => {
-			callback();
-			resolve();
-		}, time);
-	});
-}
-
-function setupRadialMenuTestPage() {
+async function setupRadialMenuTestPage() {
 	const template = `
 	<gameface-radial-menu id="radial-menu-one"
 		data-name="Radial Menu Name Test"
@@ -40,16 +31,15 @@ function setupRadialMenuTestPage() {
 
 	document.body.appendChild(el);
 
-	return new Promise(resolve => {
-		setTimeout(() => {
-			const radialMenuOne = document.getElementById('radial-menu-one');
-			// Provide the items.
-			radialMenuOne.items = itemsModel.items;
-			// the .items setter triggers a DOM change, so we wait a second to make
-			// sure the DOM is ready
-			setTimeout(resolve, 1000);
-		}, 1000);
+	await createAsyncSpec(() => {
+		const radialMenuOne = document.getElementById('radial-menu-one');
+		// Provide the items.
+		radialMenuOne.items = itemsModel.items;
 	});
+
+	// the .items setter triggers a DOM change, so we wait a bit to make
+	// sure the DOM is ready.
+	await createAsyncSpec();
 }
 
 function dispatchKeyboardEventKeyDown(keyCode, element) {
@@ -79,43 +69,19 @@ describe('Radial Menu Tests', () => {
 		it('Should be created', () => {
 			assert(document.querySelector('gameface-radial-menu').id === 'radial-menu-one', 'The id of the radial menu is not radial-menu-one.');
 		});
-	});
-
-	describe('Radial Menu', () => {
-		beforeEach(function (done) {
-			setupRadialMenuTestPage().then(done).catch(err => console.error(err));
-		});
 
 		it('Should set the provided name', () => {
 			assert(document.querySelector('.radial-menu-center-text').textContent === 'Radial Menu Name Test', 'The textContent of the radial menu is not "Radial Menu Name Test".');
 		});
-	});
-
-	describe('Radial Menu', () => {
-		beforeEach(function (done) {
-			setupRadialMenuTestPage().then(done).catch(err => console.error(err));
-		});
 
 		it('Should have items and their count to be 8', () => {
 			assert(document.querySelectorAll('.radial-menu-item').length === 8, 'The length of .radial-menu-item elements is not 8.');
-		});
-	});
-
-	describe('Radial Menu', () => {
-		beforeEach(function (done) {
-			setupRadialMenuTestPage().then(done).catch(err => console.error(err));
 		});
 
 		it('Should have background image url on a populated element', () => {
 			const backgroundImageUrl = document.querySelectorAll('.radial-menu-item-icon')[2].style.backgroundImage;
 
 			assert(backgroundImageUrl.includes('weapon3') === true, `The background image url is not "url("./images/weapon3.png")".`);
-		});
-	});
-
-	describe('Radial Menu', () => {
-		beforeEach(function (done) {
-			setupRadialMenuTestPage().then(done).catch(err => console.error(err));
 		});
 
 		it('Should have transform rotate on a populated element', () => {
@@ -124,29 +90,16 @@ describe('Radial Menu Tests', () => {
 			assert((transformValue === 'rotate(-315deg)' || transformValue === 'rotateZ(-315deg)'),
 				'The transform property of the radial-menu-item-icon is not "rotate(-315deg)" nor "rotateZ(-315deg)".');
 		});
-	});
 
-	describe('Radial Menu', () => {
-		beforeEach(function (done) {
-			setupRadialMenuTestPage().then(done).catch(err => console.error(err));
-		});
-
-		it('Should have opened on keydown', function (done) {
+		it('Should have opened on keydown', async () => {
 			const radialMenu = document.querySelector('gameface-radial-menu');
 
 			dispatchKeyboardEventKeyDown(16, window);
 
 			// The menu is opened 2 frames after the opening function is called.
-			waitForStyles(() => {
+			return createAsyncSpec(() => {
 				assert(radialMenu.classList.contains('radial-menu-open') === true, 'Radial menu did not open.');
-				done();
-			}, 2);
-		});
-	});
-
-	describe('Radial Menu', () => {
-		beforeEach(function (done) {
-			setupRadialMenuTestPage().then(done).catch(err => console.error(err));
+			});
 		});
 
 		it('Should have closed on keyup after opening', async () => {
@@ -165,12 +118,6 @@ describe('Radial Menu Tests', () => {
 			return createAsyncSpec(() => {
 				assert(radialMenu.classList.contains('radial-menu-open') === false, 'Radial menu has not closed.');
 			});
-		});
-	});
-
-	describe('Radial Menu', () => {
-		beforeEach(function (done) {
-			setupRadialMenuTestPage().then(done).catch(err => console.error(err));
 		});
 
 		it('Should successfully attach to and use custom event', async () => {

--- a/tools/tests/radio-button/test.js
+++ b/tools/tests/radio-button/test.js
@@ -32,9 +32,7 @@ function setupRadioButtonTestPage() {
     document.body.appendChild(el);
 
     return new Promise(resolve => {
-        setTimeout(() => {
-            resolve();
-        }, 1000);
+        waitForStyles(resolve);
     });
 }
 

--- a/tools/tests/router/test.js
+++ b/tools/tests/router/test.js
@@ -209,15 +209,6 @@ const routeIdToPageMap = {
     'missing': 'not-found-page',
 };
 
-function createAsyncSpec(callback, frames = 2) {
-    return new Promise(resolve => {
-        components.waitForFrames(() => {
-            callback();
-            resolve();
-        }, frames)
-    });
-}
-
 function setupRouterTestPage(history = routerHistories.BROWSER, confirmation = false) {
     const el = document.createElement('div');
     el.innerHTML = template;
@@ -263,8 +254,8 @@ function testSuite(title = 'Router Component', routerHistory = routerHistories.B
         });
 
         beforeEach(function (done) {
-            setupRouterTestPage(routerHistory, confirmation).then(done).catch(err => console.errror(err));
-        }, 3000);
+            setupRouterTestPage(routerHistory, confirmation).then(done).catch(err => console.error(err));
+        });
 
         it('Should be rendered', async () => {
             return assert(document.querySelector('gameface-route') !== null, 'The router component is not rendered.');
@@ -327,7 +318,7 @@ function testSuite(title = 'Router Component', routerHistory = routerHistories.B
 
             return createAsyncSpec(() => {
                 assert(document.querySelector(routeIdToPageMap['vowel']) !== null, 'Current page is not "vowel".');
-            })
+            });
         });
 
         it('Should show consonant page', async () => {
@@ -335,7 +326,7 @@ function testSuite(title = 'Router Component', routerHistory = routerHistories.B
 
             return createAsyncSpec(() => {
                 assert(document.querySelector(routeIdToPageMap['consonant']) !== null, 'Current page is not "consonant".');
-            })
+            });
         });
 
         it('Should automatically add active-link class to consonant page route element', async () => {

--- a/tools/tests/scrollable-container/test.js
+++ b/tools/tests/scrollable-container/test.js
@@ -2,14 +2,6 @@
  *  Copyright (c) Coherent Labs AD. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-function createAsyncSpec(callback, time = 500) {
-    return new Promise(resolve => {
-        setTimeout(() => {
-            callback();
-            resolve();
-        }, time);
-    });
-}
 
 describe('Scrollable Container Component', () => {
     afterAll(() => {
@@ -42,7 +34,9 @@ describe('Scrollable Container Component', () => {
 
         document.body.insertBefore(el, document.body.firstElementChild);
 
-        setTimeout(done, 3000);
+        waitForStyles(() => {
+            done();
+        })
     });
 
     it('Should be rendered', () => {
@@ -50,8 +44,11 @@ describe('Scrollable Container Component', () => {
     });
 
     it('Should show scrollbar if the content overflows', () => {
-        const style = getComputedStyle(document.querySelector('.slider-component')).display;
-        assert(style === 'block', 'The scrollbr is not visible.');
+        const style = getComputedStyle(document.querySelector('.slider-component'));
+
+        return createAsyncSpec(() => {
+            assert(style.display === 'block', 'The scrollbar is not visible.');
+        });
     });
 
     it('Should scroll using the control buttons', async () => {
@@ -61,11 +58,11 @@ describe('Scrollable Container Component', () => {
         await createAsyncSpec(() => {
             assert(parseInt(getComputedStyle(handle).top) === 0, 'The scrollbar handle is not at the top.');
             downButton.dispatchEvent(new CustomEvent('mousedown', {}));
-        }, 1000);
+        });
 
         await createAsyncSpec(() => {
             downButton.dispatchEvent(new CustomEvent('mouseup', { bubbles: true }));
-        }, 1000);
+        });
 
         return createAsyncSpec(() => {
             assert(parseInt(getComputedStyle(handle).top) !== 0, 'The scrollbar handle is at the top.');

--- a/tools/tests/switch/test.js
+++ b/tools/tests/switch/test.js
@@ -12,7 +12,7 @@ const loadSwitch = ({ type, disabled, checked, checkText, uncheckText }) => {
     document.body.appendChild(wrapper.firstChild);
 
     return new Promise((resolve) => {
-        waitForStyles(resolve, 3);
+        waitForStyles(resolve);
     });
 };
 

--- a/tools/tests/tabs/test.js
+++ b/tools/tests/tabs/test.js
@@ -27,9 +27,9 @@ describe('Tabs Components', () => {
         const el = document.createElement('gameface-tabs');
         document.body.appendChild(el);
 
-        setTimeout(() => {
+        waitForStyles(() => {
             done();
-        }, 2000);
+        });
     });
 
     it('Should be rendered', () => {


### PR DESCRIPTION
This review includes:
* Replaced timers with our utility function for waiting for frames/styles.
* United tests from multiple describes into a single one.
* Renamed (global) functions which clashed after fixing one of the dropdown tests (function needs to be a utility one and reused but in another task)
and some other cleanups.