### PR TITLE
Properly check if the component exists in the npm registry

### DIFF
--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -17,7 +17,7 @@ function shouldUpdate(component, folder = COMPONENTS_PATH) {
     const name = packageJSON.name;
 
     // if a component doesn't exist in the registry then it must be published
-    if (!execSync(`npm search ${name} --json`).length) return true;
+    if (!JSON.parse(execSync(`npm search ${name} --json`, {encoding: 'utf8'})).length) return true;
 
     const localVersion = packageJSON.version;
     const publicVersion = getPublicVersion(name);


### PR DESCRIPTION
Check if a component exists in the npm registry by doing `npm search --json` , but parse the json response.