### PR TITLE
Added workflow for deploying to GH Pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,35 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches:
+      - master  # Deploy on pushing to the default branch
+  pull_request:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true  # Fetch Hugo themes (true OR recursive)
+          fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: '0.76.5'
+          extended: false
+
+      - name: Build with Hugo
+        run: hugo -D -F
+        working-directory: ./docs/
+
+      - name: Deploy to target branch # Takes the content from publish_dir: which is going to gh-pages branch automatically.
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.ref == 'refs/heads/master' }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/public

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -1,4 +1,4 @@
-baseURL = "http://CoherentLabs.github.io/GameUIComponents"
+baseURL = "https://CoherentLabs.github.io/GameUIComponents"
 
 languageCode = "en-us"
 DefaultContentLanguage = "en"


### PR DESCRIPTION
* Rename every http to https in *html pages (script) - we initially did this otherwise GitHub will refuse to load the styles from **http://** (https://docs.github.com/en/pages/getting-started-with-github-pages/securing-your-github-pages-site-with-https).

Do read the Test plan in the task.