### PR TITLE
Tooltip smart position

### DIFF
--- a/components/tooltip/demo/demo.html
+++ b/components/tooltip/demo/demo.html
@@ -66,7 +66,7 @@
             <div class="manual">Click me</div>
         </div>
     </div>
-    <gameface-tooltip id="tutorial" target=".manual" on="click" position="top" off="click">
+    <gameface-tooltip id="tutorial" target=".manual" on="click" position="bottom" off="click">
         <div slot="message">
             <div class="container">
                 <div class="title">Wellcome!</div>

--- a/components/tooltip/package.json
+++ b/components/tooltip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coherent-gameface-tooltip",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A tooltip component for Coherent Labs' Gameface.",
   "main": "script.js",
   "scripts": {

--- a/components/tooltip/script.js
+++ b/components/tooltip/script.js
@@ -112,6 +112,8 @@ class Tooltip extends HTMLElement {
                 break;
         }
 
+        this.position = orientation;
+
         this.style.top = scrollOffsetY + position.top + 'px';
         this.style.left = scrollOffsetX + position.left + 'px';
 

--- a/components/tooltip/script.js
+++ b/components/tooltip/script.js
@@ -75,6 +75,9 @@ class Tooltip extends HTMLElement {
             left: elementSize.left + (elementSize.width / 2) - tooltipSize.width / 2
         }
 
+        const scrollOffsetX = window.scrollX;
+        const scrollOffsetY = window.scrollY;
+
         switch (this.position) {
             case 'top':
                 position.top = elementSize.top - TOOLTIP_MARGIN - tooltipSize.height;
@@ -95,10 +98,41 @@ class Tooltip extends HTMLElement {
                 break;
         }
 
-        this.style.top = position.top + 'px';
-        this.style.left = position.left + 'px';
+        this.style.top = scrollOffsetY + position.top + 'px';
+        this.style.left = scrollOffsetX + position.left + 'px';
         this.style.visibility = 'visible';
         this.visible = true;
+    }
+
+    overflows() {
+        var rect = this.getBoundingClientRect();
+
+        const overflows = {};
+
+        if (rect.top < 0) overflows.top = true;
+        if (rect.left < 0)  overflows.left = true;
+        if (rect.right > (window.innerWidth || document.documentElement.clientWidth)) overflows.right = true;
+        if (rect.bottom > (window.innerHeight || document.documentElement.clientHeight)) overflows.bottom = true;
+
+        return overflows;
+    }
+
+    getPosition() {
+        const opposingSites = {
+            top: 'bottom',
+            bottom: 'top',
+            left: 'right',
+            right: 'left'
+
+        }
+        const overflows = this.overflows();
+        const overflowingSides = object.keys(overflows);
+
+        let position;
+
+        if (overflowingSides.length === 1) position = opposingSites[overflowingSides[0]];
+
+        return position;
     }
 }
 

--- a/components/tooltip/style.css
+++ b/components/tooltip/style.css
@@ -13,3 +13,16 @@
     border-radius: 10px;
     overflow-wrap: break-word;
 }
+
+.tooltip-show-animation {
+    animation: fadein 1s;
+    animation-fill-mode: forwards;
+}
+@keyframes fadein {
+   from {
+       opacity:0;
+   }
+   to {
+       opacity:1;
+   }
+}

--- a/tools/tests/package.json
+++ b/tools/tests/package.json
@@ -18,7 +18,7 @@
       "coherent-gameface-slider": "^1.0.6",
       "coherent-gameface-switch": "^1.0.2",
       "coherent-gameface-tabs": "^1.0.7",
-      "coherent-gameface-tooltip": "^1.0.3",
+      "coherent-gameface-tooltip": "^1.0.4",
       "coherent-gameface-text-field": "^1.0.1",
       "coherent-gameface-accordion-menu": "^1.0.1"
     },

--- a/tools/tests/tooltip/test.js
+++ b/tools/tests/tooltip/test.js
@@ -10,7 +10,13 @@ const tooltipTemplate = `
 <gameface-tooltip id="default-to-top" target=".target" on="click" position="notexistingposition" off="click">
 <div slot="message">Should be on top</div>
 </gameface-tooltip>
-<div class="target" style="background-color: #6e6d6d;position: absolute; top: 500px; left: 500px;width:100px;height:50px;">Hover over me</div>`;
+
+<gameface-tooltip id="smart-position" target=".smart-position-target" on="click" position="top" off="click">
+<div slot="message">Should be on top</div>
+</gameface-tooltip>
+<div class="target" style="background-color: #6e6d6d;position: absolute; top: 500px; left: 500px;width:100px;height:50px;">Hover over me</div>;
+<div class="smart-position-target" style="background-color: #6e6d6d;position: absolute; top: 20px; left: 30px;width:100px;height:50px;">click me</div>`;
+
 
 
 function setupTooltipTestPage() {
@@ -74,6 +80,16 @@ describe('Tooltip component', () => {
         return createAsyncSpec(() => {
             const tooltip = document.querySelector('#default-to-top');
             assert(tooltip.position === 'top', 'Tooltip was no displayed on top.');
+        }, 5);
+    });
+
+    it('Should not be displayed on top as there is not enought space for the tooltip to be visible', async () => {
+        const target = document.querySelector('.smart-position-target');
+        click(target);
+
+        return createAsyncSpec(() => {
+            const tooltip = document.querySelector('#smart-position');
+            assert(tooltip.position !== 'top', 'Tooltip was displayed on top.');
         }, 5);
     });
 });


### PR DESCRIPTION
- Change the position of the tooltip if it isn't visible with the current settings.
- Use only the pre-defined positions as they are all anchored on the tooltip target, If we move the tooltip too much it  might become unclear which is its target, for example in a form with multiple elements which are close to each other.
- Check if the tooltip overflows out of the windows, not its container element, as all tooltips are absolutely positioned to the body. 
- In case of need of repositioning we try all possible orientations (top, left, right and bottom) until wee either find  one that is suitable or we've tried all and none fixed the issue.
- Added test case for one position as the logic is the same for all and there's no need to check them individually.