### PR TITLE
Simplify dropdown code

### DIFF
--- a/components/dropdown/package.json
+++ b/components/dropdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coherent-gameface-dropdown",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "description": "A component for Coherent Labs Gameface.",
   "main": "script.js",
   "repository": {

--- a/components/dropdown/script.js
+++ b/components/dropdown/script.js
@@ -250,10 +250,30 @@ class GamefaceDropdown extends CustomElementValidator {
      * This is executed when the dropdown is connected to the DOM.
     */
     setInitialSelection() {
+        if (this.multiple) return this.setInitialMultipleSelection();
+        this.setInitialSingleSelection();
+    }
+
+    /**
+     * Select all options that have the selected attribute
+    */
+    setInitialMultipleSelection() {
         for (const option of this.allOptions) {
             if (!option.hasAttribute('selected')) continue;
             this.setSelected(option);
         }
+    }
+
+    /**
+     * Select the last found option that has the selected attribute.
+     * If none is found - selects the first element from the options list
+    */
+    setInitialSingleSelection() {
+        const allSelected = this.querySelectorAll('[selected]');
+        const selectedLength = allSelected.length;
+        // use the last option that has the selected attribute or the first element in the options list
+        const selectedDefault = selectedLength ? allSelected[selectedLength -1] : this.selected;
+        this.setSelected(selectedDefault);
     }
 
     /**
@@ -349,6 +369,8 @@ class GamefaceDropdown extends CustomElementValidator {
             this.selected = allOptions[enabledOptions[start]];
             start += direction;
         } while (!this.isOutOfRange(start, end, direction));
+
+        this.scrollToSelectedElement();
     }
 
     /**
@@ -440,31 +462,27 @@ class GamefaceDropdown extends CustomElementValidator {
             case KEYCODES.HOME:
             case KEYCODES.PAGE_UP:
                 // focus first
-                this.selectFromTo(0, 0);
-                this.scrollToSelectedElement();
+                nextElement = 0;
                 break;
             case KEYCODES.END:
             case KEYCODES.PAGE_DOWN:
                 // focus last
                 nextElement = enabledOptions.length - 1;
-                this.selectFromTo(nextElement, nextElement);
-                this.scrollToSelectedElement();
                 break;
             case KEYCODES.UP:
             case KEYCODES.LEFT:
                 nextElement = currentOptionIndex - 1;
                 if (this.isOutOfRange(nextElement, 0, -1)) return;
-                this.selectFromTo(nextElement, nextElement);
-                this.scrollToSelectedElement();
                 break;
             case KEYCODES.DOWN:
             case KEYCODES.RIGHT:
                 nextElement = currentOptionIndex + 1;
                 if (this.isOutOfRange(nextElement, enabledOptions.length-1, 1)) return;
-                this.selectFromTo(nextElement, nextElement);
-                this.scrollToSelectedElement();
                 break;
         }
+
+        this.resetSelection();
+        this.setSelected(this.allOptions[enabledOptions[nextElement]], true);
     }
 
     /**

--- a/components/form-control/package.json
+++ b/components/form-control/package.json
@@ -16,7 +16,7 @@
     "coherent-gameface-components": "^1.0.5",
     "coherent-gameface-checkbox": "^1.0.5",
     "coherent-gameface-radio-button": "^1.0.1",
-    "coherent-gameface-switch": "^1.0.1",
+    "coherent-gameface-switch": "^1.1.0",
     "coherent-gameface-rangeslider": "^1.0.4",
     "coherent-gameface-dropdown": "^1.0.6",
     "postmessage-polyfill": "1.0.0",

--- a/lib/components.js
+++ b/lib/components.js
@@ -314,6 +314,7 @@ const components = function () {
         SPACE: 32,
         PAGE_UP: 33,
         PAGE_DOWN: 34,
+        LETTER_A: 65,
     };
 
     class GamefaceComponents {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coherent-gameface-components",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "A UI components library for the Web.",
   "main": "components.js",
   "scripts": {

--- a/tools/tests/dropdown/multiple-dropdown.test.js
+++ b/tools/tests/dropdown/multiple-dropdown.test.js
@@ -176,8 +176,8 @@ describe('Multiple Dropdown Test', () => {
             options[1].onClick({ target: options[1], ctrlKey: true });
             options[2].onClick({ target: options[2], ctrlKey: true });
 
-            assert(dropdown.selectedOptions.length === 3,
-                `Expected selected options length to be 3, got ${dropdown.selectedOptions.length}.`);
+            assert(dropdown.selectedOptions.length === 2,
+                `Expected selected options length to be 2, got ${dropdown.selectedOptions.length}.`);
         });
 
         it('Should deselect multiple elements', () => {
@@ -191,7 +191,7 @@ describe('Multiple Dropdown Test', () => {
             options[1].onClick({ target: options[1], ctrlKey: true });
             options[2].onClick({ target: options[2], ctrlKey: true });
 
-            assert(dropdown.selectedOptions.length === 1,
+            assert(dropdown.selectedOptions.length === 0,
               `It didn't select only one element. Expected selected options length to be 1, got ${dropdown.selectedOptions.length}.`);
         });
 
@@ -210,7 +210,7 @@ describe('Multiple Dropdown Test', () => {
         });
     });
 
-    describe('Multiple Dropdown Component', () => {
+    describe('Multiple Dropdown Component Collapsable', () => {
         beforeEach(function (done) {
             setupMultipleDropdownTestPage(multipleDropdownCollapsableTemplate).then(done).catch(err => console.error(err));
         });
@@ -233,12 +233,12 @@ describe('Multiple Dropdown Test', () => {
             setupMultipleDropdownTestPage(multipleDropdownPreselectedOptionsTemplate).then(done).catch(err => console.error(err));
         });
 
-        it('Three options should be (pre)selected.', async () => {
+        it('Two options should be (pre)selected.', async () => {
             const dropdown = document.querySelector('gameface-dropdown');
             const selectedOptions = dropdown.selectedOptions;
 
             await createAsyncSpec(() => {
-                assert.equal(selectedOptions.length, 3, 'The (pre)selected options are not 3.');
+                assert.equal(selectedOptions.length, 2, 'The (pre)selected options are not 2.');
             });
         });
     });

--- a/tools/tests/form-control/spec/test.js
+++ b/tools/tests/form-control/spec/test.js
@@ -63,9 +63,9 @@ const forms = [
 	{
 		testName: formsTestNames.DROPDOWN_FORM,
 		id: formsIds.DROPDOWN_FORM,
-		submitData: '{"option1":"1","option2":"Two","option4":"Two","option5":["1","Two","3"]}',
+		submitData: '{"option1":"1","option2":"Two","option4":"Two","option5":["Two","3"]}',
 		// Expected options will change when the caching feature is reworked or removed.
-		submitDataInteraction: '{"option1":"2","option2":"Two","option4":"Two","option5":["1","3","Two","3"]}',
+		submitDataInteraction: '{"option1":"2","option2":"Two","option4":"Two","option5":"3"}',
 		template: DROPDOWN_TEMPLATE,
 	},
 ];
@@ -164,7 +164,6 @@ function setFormTestCasesWithInteraction() {
 						for (let i = 0; i < dropdowns.length - 1; i++) {
 							click(dropdowns[i].querySelectorAll('dropdown-option')[1]);
 						}
-
 						multipleSelectOptionTwo.onClick({ target: multipleSelectOptionTwo, ctrlKey: true });
 						break;
 				}

--- a/tools/tests/package.json
+++ b/tools/tests/package.json
@@ -4,7 +4,7 @@
       "coherent-gameface-automatic-grid": "^1.0.7",
       "coherent-gameface-components": "^1.0.6",
       "coherent-gameface-checkbox": "^1.0.6",
-      "coherent-gameface-dropdown": "^1.0.7",
+      "coherent-gameface-dropdown": "^1.1.0",
       "coherent-gameface-form-control": "^1.0.3",
       "coherent-gameface-grid": "^1.0.3",
       "coherent-gameface-menu": "^1.0.8",


### PR DESCRIPTION
Shorten the methods of the dropdown.
Add more comments.
Use one method for selection.
Separate select from select.
Separate the multiple from the single logic where possible.
Move all private own state object to getters to simplify usage- instead of manually updating the selectedList etc. do it through the selected setter.
Use ONLY the selected setter or the setSelected methods to update selection.
Remove unused function.
Move repeated code to smaller functions.