### PR TITLE
Native scrollbar is hidden now for browsers different from Gameface

### DIFF
--- a/components/dropdown/package.json
+++ b/components/dropdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coherent-gameface-dropdown",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "A component for Coherent Labs Gameface.",
   "main": "script.js",
   "repository": {
@@ -13,8 +13,8 @@
     "Component"
   ],
   "dependencies": {
-    "coherent-gameface-components": "^1.0.5",
-    "coherent-gameface-scrollable-container": "^1.0.6",
+    "coherent-gameface-components": "^1.0.9",
+    "coherent-gameface-scrollable-container": "^1.0.10",
     "postmessage-polyfill": "1.0.0",
     "whatwg-fetch": "3.4.1"
   },

--- a/components/dropdown/script.js
+++ b/components/dropdown/script.js
@@ -537,14 +537,6 @@ class GamefaceDropdown extends CustomElementValidator {
     }
 
     /**
-     * Checks if the current user agent is Cohtml
-     * @returns {boolean}
-    */
-    isGameface() {
-        return navigator.userAgent.match('Cohtml');
-    }
-
-    /**
      * Called on click on the select element.
      * Toggles the options panel, shows the scrollbar and scrolls to
      * the selected option element.
@@ -566,7 +558,7 @@ class GamefaceDropdown extends CustomElementValidator {
     initScrollbar() {
         const scrollableContainer = this.querySelector('gameface-scrollable-container');
 
-        if (!this.isGameface()) return scrollableContainer.querySelector('.guic-scrollable-container').classList.add('full-width');
+        if (!components.isBrowserGameface()) return scrollableContainer.querySelector('.guic-scrollable-container').classList.add('full-width');
         scrollableContainer.shouldShowScrollbar();
     }
 

--- a/components/dropdown/template.html
+++ b/components/dropdown/template.html
@@ -5,7 +5,7 @@
         <div class="guic-dropdown-custom-select-arrow"></div>
     </div>
     <div class="guic-dropdown-options-container guic-dropdown-hidden">
-        <gameface-scrollable-container class="scrollable-container-component">
+        <gameface-scrollable-container class="scrollable-container-component" automatic>
             <div slot="scrollable-content" data-name="scrollable-content">
                 <div class="guic-dropdown-options">
                     <component-slot data-name="option"></component-slot>

--- a/components/scrollable-container/CHANGELOG.md
+++ b/components/scrollable-container/CHANGELOG.md
@@ -1,0 +1,5 @@
+<!-- Remove/use this changelog when we setup the automatized system for generating the changelog -->
+# 1.0.10
+| *   | Description                                                                                                 |
+| --- | ----------------------------------------------------------------------------------------------------------- |
+| Fix | The native scrollbar is not visible anymore when gameface-scrollable-container is used outside of Gameface. |

--- a/components/scrollable-container/demo/demo.html
+++ b/components/scrollable-container/demo/demo.html
@@ -67,12 +67,15 @@
                 <button class="show-dynamic-content">Show more data</button>
                 <button class="hide-dynamic-content">Hide data</button>
                 <button class="remove-auto-attribute">Remove Auto</button>
-                <button class="add-auto-attribute">Make Aouto</button>
+                <button class="add-auto-attribute">Make Auto</button>
             </div>
+            Mode: <span id="mode">Non automatic</span>
         </div>
     </div>
     <script src="./bundle.js"></script>
     <script>
+        const modeElement = document.getElementById('mode');
+
         document.querySelector('.show-dynamic-content').addEventListener('click', () => {
             document.querySelector('.dynamic-content').style.display = 'block';
         });
@@ -81,9 +84,11 @@
         });
         document.querySelector('.remove-auto-attribute').addEventListener('click', () => {
             document.querySelector('.auto').removeAttribute('automatic');
+            modeElement.textContent = 'Non automatic';
         });
         document.querySelector('.add-auto-attribute').addEventListener('click', () => {
             document.querySelector('.auto').setAttribute('automatic', 'automatic');
+            modeElement.textContent = 'Automatic';
         });
     </script>
 </body>

--- a/components/scrollable-container/package.json
+++ b/components/scrollable-container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coherent-gameface-scrollable-container",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "A component for Coherent Labs Gameface.",
   "main": "script.js",
   "repository": {
@@ -13,7 +13,7 @@
     "Component"
   ],
   "dependencies": {
-    "coherent-gameface-components": "^1.0.5",
+    "coherent-gameface-components": "^1.0.9",
     "coherent-gameface-slider": "^1.0.5",
     "postmessage-polyfill": "1.0.0",
     "whatwg-fetch": "3.4.1"

--- a/components/scrollable-container/script.js
+++ b/components/scrollable-container/script.js
@@ -97,7 +97,7 @@ class ScrollableContainer extends HTMLElement {
     setup() {
         this.scrollableContainer = this.getElementsByClassName('guic-scrollable-container')[0];
         this.scrollbar = this.getElementsByClassName('guic-slider-component')[0];
-
+        if (!components.isBrowserGameface()) this.scrollableContainer.classList.add('guic-native-scroll-disabled');
         this.addEventListeners();
     }
 
@@ -169,6 +169,8 @@ class ScrollableContainer extends HTMLElement {
 
     /**
      * Checks if a scrollbar should be visible.
+     * @warning - Be careful! Any mutation to the scrollable container in this method will cause a memory leak!
+     * For example this.scrollableContainer.classList.add('some-class').
     */
     shouldShowScrollbar() {
         const scrollableContent = this.querySelector('[data-name="scrollable-content"]');
@@ -183,5 +185,29 @@ class ScrollableContainer extends HTMLElement {
         });
     }
 }
+
+/**
+ * Will add styles for the non Coherent browsers that are disabling the native scrollbar
+ */
+function addDisabledNativeScrollbarStyles() {
+    const style = document.createElement('style');
+    style.innerHTML = `
+        .guic-native-scroll-disabled {
+            -ms-overflow-style: none;
+            scrollbar-width: none;
+        }
+        .guic-native-scroll-disabled::-webkit-scrollbar {
+            display: none;
+        }`;
+    document.head.appendChild(style);
+}
+
+if (!components.isBrowserGameface() && !components.nativeScrollDisabledStylesAdded) {
+    addDisabledNativeScrollbarStyles();
+    // We are doing this to prevent readdition of the styles needed for the native scrollbar to not be visible.
+    // This problem is produced when multiple components have the scrollable container bundled.
+    components.nativeScrollDisabledStylesAdded = true;
+}
+
 components.defineCustomElement('gameface-scrollable-container', ScrollableContainer);
 export default ScrollableContainer;

--- a/lib/components.js
+++ b/lib/components.js
@@ -683,6 +683,14 @@ const components = function () {
             count--;
             requestAnimationFrame(() => this.waitForFrames(callback, count));
         }
+
+        /**
+         * Checks if the current user agent is Cohtml
+         * @returns {boolean}
+        */
+        isBrowserGameface() {
+            return navigator.userAgent.match('Cohtml');
+        }
     }
 
     const components = new GamefaceComponents();

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coherent-gameface-components",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "A UI components library for the Web.",
   "main": "components.js",
   "scripts": {


### PR DESCRIPTION
- [x] Self-reviewed and fixed any obvious mistakes, TODOs, removed debugging code, logs, etc
- [x] Updated package.json in related components, the library or the cli
- [x] Tested in a browser
- [x] Tested in Gameface
- [x] Tested demo in index.html in root ot the repository

* Native scrollbar is not visible in chrome
* Dropdown now uses scrollbar with automatic resize
* Made util method inside the components library for checking if components are ran inside Gameface - `isBrowserGameface`
* Bumped the versions of the components library in package.jsons of the components that are using `isBrowserGameface` method
* Bumped the versions of the scrollable container in package.jsons of the components that are using it (dropdown).
