### PR TITLE
Change the way we generate the search index code

### DIFF
--- a/docs/assets/js/search-utilities.js
+++ b/docs/assets/js/search-utilities.js
@@ -74,19 +74,16 @@ var docs = [
 {{ $list := .Site.Pages  -}}
 {{ $len := (len $list) -}}
 
+{{ range $index, $element := $list -}}
 index.add(
-  {{ range $index, $element := $list -}}
     {
       id: {{ $index }},
       href: "{{ .RelPermalink }}",
       title: {{ .Title | jsonify }},
       content: {{ .Plain | jsonify }},
       lowerCaseContent: ({{ .Plain | jsonify }}).toLowerCase()
-    })
-    {{ if ne (add $index 1) $len -}}
-      .add(
-    {{ end -}}
-  {{ end -}}
+    });
+{{ end -}}
       
 ;
 


### PR DESCRIPTION
If we have a lot of content, the old code lead to `index.add().add().add()...` repeated thousands of times, which can exceed the JS callstack maximum size and thus break the search. The new code just does `index.add(); index.add() ...`, which results in subsequent calls that do not depend on one another

- Tested in Chrome


