### PR TITLE
[Enhancement] Add script to check for split sentences in markdown docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,3 +400,15 @@ To prevent errors, improve the code quality and readability, to make maintainabl
 * If you want to check anytime if you have some linter errors you can run `npm run lint:errors`. If you want to check for warnings as well you can run `npm run lint:all`. We advise you to use `lint:all` command!
 * You can install a [VSCode extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) that will run the linter in the background while you are coding. This will save you time fixing the errors at the end.
 * We added a GitHub action that will be triggered when you make a pull request. It will run the linter each time you make a change to the pull request to make sure everything is fine with the code.
+
+# Configuring the Python environment
+
+Currently, we still rely on [**Python2.7**](https://www.python.org/downloads/release/python-272/) for the execution of our scripts.
+This means that if you get weird errors, you probably have to double-check if you have Python2.7 installed on your system.
+
+In case you have previously installed Python3 only, to ensure that when `python` is called in a console environment, you must make sure that your Python2 installation location is included in your `Path` environment variable before the Python3 installation.
+
+Also, a common way to be able to call both Python2 and Python3 executions of scripts is to navigate to your Python3 install location (after configuring the `Path` environment variable as described above) and symlink your `python.exe` in the same directory and name it `python3.exe`.
+This way you will be able to easily call a script like so - `python3 somescript.py` - and let it be executed by Python3
+
+You can also opt for a [virtualenv setup](https://help.dreamhost.com/hc/en-us/articles/215489338-Installing-and-using-virtualenv-with-Python-2).

--- a/docs/split_sentence_checker.py
+++ b/docs/split_sentence_checker.py
@@ -1,0 +1,111 @@
+from __future__ import print_function
+import argparse
+import os
+import re
+from importlib import import_module
+from subprocess import call
+
+
+def install_and_import(package):
+    try:
+        import_module(package)
+    except ImportError:
+        print('The Python2 "mistune" module was missing from your system. Installing it for you now!')
+        call(["pip", "install", package])
+    finally:
+        globals()[package] = import_module(package)
+
+
+# Make sure mistune module is installed
+# This has to be called before the next line
+# because it is needed for the NewLinesDetector
+# class which is inheriting from a mistune class
+install_and_import('mistune')
+
+
+class NewlinesDetector(mistune.HTMLRenderer):
+    split_sentences = False
+    faulty_sentences = []
+
+    def paragraph(self, text):
+        if '\n' in text or '\r' in text:
+            self.split_sentences = True
+            self.faulty_sentences.append(text)
+        return mistune.HTMLRenderer.paragraph(self, text)
+
+    def split_sentences_detected(self):
+        return self.split_sentences
+
+    def get_faulty_sentences(self):
+        return self.faulty_sentences
+
+    def reset(self):
+        self.split_sentences = False
+        self.faulty_sentences = []
+
+
+def convert_to_html_and_parse(dir):
+    faulty_files = []
+    new_lines_detector = NewlinesDetector()
+    for root, _, files in os.walk(dir):
+        # Skip the API Reference directory, as we don't format that
+        if 'api_reference' in root.lower():
+            continue
+        for file in files:
+            if file.endswith('.md') and file != 'Copyright.md':
+                markdown_file = os.path.join(root, file)
+                with open(markdown_file, 'r') as file:
+                    content = file.read()
+                    # We need to trim this pattern, to not generate errors
+                    # Looking for the start of each Hugo markdown:
+                    # ---
+                    # *Anything in between, but we must have a title*
+                    # title *Anything and ignoring position of :*
+                    # *Anything in between*
+                    # ---
+                    pattern = r"(?s)---\n.*?(title).*?---"
+                    content = re.sub(pattern, '', content)
+                    # We use the default settings that are used
+                    # when calling mitsune.html(), in order to
+                    # not generate errors for certain formats
+                    markdown = mistune.create_markdown(
+                        escape=False,
+                        renderer=new_lines_detector,
+                        plugins=['strikethrough', 'footnotes', 'table'],
+                    )
+                    markdown(content)
+                if new_lines_detector.split_sentences_detected():
+                    faulty_files.append((markdown_file, new_lines_detector.get_faulty_sentences()))
+                    new_lines_detector.reset()
+
+    if faulty_files:
+        print('The following files contain split sentences:\n')
+        for file, faulty_sentences in faulty_files:
+            print('File "%s":' % file)
+            for sentence in faulty_sentences:
+                print('"%s"\n' % sentence)
+        error_msg = (
+            "Error: Encountered new lines in one or more paragraph(s)! "
+            "Please rewrite your sentence(s) to be on the same line!"
+        )
+        raise Exception(error_msg)
+    else:
+        print('All files are properly formatted!')
+
+
+def main():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('--directory', '-d', help='A directory path to search recursively for markdown files.')
+
+    options = parser.parse_args()
+
+    if options.directory is not None:
+        print('Checking markdown files for illegal newlines...\n')
+        convert_to_html_and_parse(options.directory)
+    else:
+        print('You must provide a directory path!')
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/add_git_hooks.py
+++ b/tools/add_git_hooks.py
@@ -1,0 +1,35 @@
+import os
+import glob
+import stat
+
+
+def generate_hooks(repo_root, hooks_dir, dest):
+    stub_format = """#!/bin/bash
+if [ -f "{0}" ]
+then
+    exec "{0}" $@
+else
+    echo "Skipping hook {0} since it does not exist."
+fi
+"""
+    hooks_list = glob.glob(hooks_dir + "/*")
+    for hook in hooks_list:
+        hook_name = os.path.join(dest, os.path.basename(hook))
+        hook_from_repo = os.path.relpath(hook, repo_root)
+
+        with open(hook_name, 'w') as f:
+            f.write(stub_format.format(hook_from_repo.replace('\\', '/')))
+        os.chmod(hook_name, stat.S_IRWXU)
+
+
+def copy_hooks(base_dir):
+    hooks_dir = os.path.join(base_dir, 'tools/hooks')
+    dest = os.path.join(base_dir, '.git/hooks')
+    generate_hooks(base_dir, hooks_dir, dest)
+
+
+if __name__ == '__main__':
+    print('Copying hooks')
+    base_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..')
+    copy_hooks(base_dir)
+    print('Done')

--- a/tools/hooks/pre-commit
+++ b/tools/hooks/pre-commit
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+ret=$?
+if [ $ret -ne 0 ]; then
+	exit 1
+fi
+
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+    against=HEAD
+else
+    # Initial commit: diff against an empty tree object
+    against=$(git hash-object -t tree /dev/null)
+fi
+
+changed_files=$(git diff --cached --name-only --diff-filter=ACM $against |
+              tr '\r\n' ' ' | tr '\n' ' ')
+
+case "$changed_files" in
+	*"docs/content"*)
+		# echo $changed_files
+		# Uncomment when we add spellcheck.py
+		# echo 'Documentation is changed. Running spellcheck...'
+		# python docs/spellcheck.py --report
+		echo 'Checking for split sentences...'
+		python docs/split_sentence_checker.py -d "docs/content"
+		ret=$?
+		if [ $ret -ne 0 ]; then
+			exit 1
+		fi
+esac


### PR DESCRIPTION
[COH-16953]
- Additionally added a git hook
- Also added a script to add hooks

* The script will check all the docs under the `content` dir
  * Every illegally split sentence in a given file will be logged
* The hook will call the script
  * Main dependencies are having Python2 and the [mistune module](https://mistune.lepture.com/en/latest/index.html)
    * `mistune` will be automatically installed if it is missing

[COH-16953]: https://coherent-labs.atlassian.net/browse/COH-16953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ