### PR TITLE
Migrate webpack-dev-server config to v4

### DIFF
--- a/components/automatic-grid/demo/demo.html
+++ b/components/automatic-grid/demo/demo.html
@@ -1,7 +1,7 @@
 <!--Copyright (c) Coherent Labs AD. All rights reserved. Licensed under the MIT License. See License.txt in the project root for license information. -->
 <!DOCTYPE html>
 <html lang="en">
-<link rel="stylesheet" href="../../grid/dist/grid.production.min.css">
+<link rel="stylesheet" href="../node_modules/coherent-gameface-grid/dist/grid.production.min.css">
 <link rel="stylesheet" href="../coherent-gameface-components-theme.css">
 <link rel="stylesheet" href="../style.css">
 

--- a/components/automatic-grid/package.json
+++ b/components/automatic-grid/package.json
@@ -15,7 +15,8 @@
   "dependencies": {
     "coherent-gameface-components": "^1.0.5",
     "postmessage-polyfill": "1.0.0",
-    "whatwg-fetch": "3.4.1"
+    "whatwg-fetch": "3.4.1",
+    "coherent-gameface-grid": "1.0.3"
   },
   "author": "CoherentLabs",
   "license": "ISC"

--- a/tools/cli/commands/build-demo.js
+++ b/tools/cli/commands/build-demo.js
@@ -3,26 +3,19 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-const path = require('path');
 const webpack = require('webpack');
+const webpackBaseConfig = require('../config/webpack-base-config');
 
 /**
  * Builds the demo of the component.
  * @param {boolean} [dev=false]
 */
 function buildDemo(dev = false) {
-    const pathToDemo = path.resolve(path.join(process.cwd(), 'demo'));
-
     webpack({
-        mode: dev ? 'development' : 'production',
-        entry: path.join(pathToDemo, 'demo.js'),
-        devtool: false,
-        resolve: {
-            symlinks: true,
-        },
-        output: {
-            path: pathToDemo,
-            filename: 'bundle.js',
+        ...webpackBaseConfig,
+        ...{
+            mode: dev ? 'development' : 'production',
+            devtool: false,
         },
     }, (err, stats) => { // Stats Object
         if (err) {

--- a/tools/cli/commands/start-demo.js
+++ b/tools/cli/commands/start-demo.js
@@ -6,40 +6,36 @@
 const path = require('path');
 const webpack = require('webpack');
 const WebpackDevServer = require('webpack-dev-server');
+const webpackBaseConfig = require('../config/webpack-base-config');
 
 const PORT = 3000;
+const pathToDemo = path.resolve(path.join(process.cwd(), 'demo'));
+
+const devServerOptions = {
+    static: {
+        directory: path.join(pathToDemo, '../'),
+        watch: {
+            ignored: 'demo/',
+        },
+    },
+    open: 'http://localhost:3000/demo/demo.html',
+    allowedHosts: 'all',
+    hot: false,
+    port: PORT,
+};
+
+const webpackConfig = { ...webpackBaseConfig, devServer: devServerOptions };
 
 /**
  * Will start the demo
  */
 function startDemo() {
-    const pathToDemo = path.resolve(path.join(process.cwd(), 'demo'));
+    const compiler = webpack(webpackConfig);
+    const devServerOptions = { ...webpackConfig.devServer };
+    const server = new WebpackDevServer(devServerOptions, compiler);
 
-    const compiler = webpack({
-        mode: 'development',
-        devtool: false,
-        entry: path.join(pathToDemo, 'demo.js'),
-        output: {
-            path: pathToDemo,
-            filename: 'bundle.js',
-        },
-    });
-
-    const server = new WebpackDevServer(compiler, {
-        contentBase: path.join(pathToDemo),
-        publicPath: `http://localhost:${PORT}/`,
-        watchContentBase: true,
-        port: PORT,
-        hot: true,
-        disableHostCheck: true,
-        watchOptions: {
-            poll: 500,
-        },
-    });
-
-
-    server.listen(PORT, '127.0.0.1', () => {
-        console.log(`Starting server on http://localhost:${PORT}`);
+    server.startCallback(() => {
+        console.log('Successfully started server on http://localhost:3000');
     });
 }
 

--- a/tools/cli/config/webpack-base-config.js
+++ b/tools/cli/config/webpack-base-config.js
@@ -1,0 +1,17 @@
+const path = require('path');
+const pathToDemo = path.resolve(path.join(process.cwd(), 'demo'));
+
+const webpackConfig = {
+    mode: 'development',
+    entry: path.join(process.cwd(), 'demo/demo.js'),
+    devtool: false,
+    resolve: {
+        symlinks: true,
+    },
+    output: {
+        path: pathToDemo,
+        filename: 'bundle.js',
+    },
+};
+
+module.exports = webpackConfig;

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coherent-guic-cli",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "A command line interface for creating Game UI Components for Gameface.",
   "main": "index.js",
   "scripts": {
@@ -20,8 +20,8 @@
     "rollup-plugin-multi-input": "1.1.1",
     "rollup-plugin-terser": "7.0.2",
     "webpack": "5.4.0",
-    "webpack-cli": "4.1.0",
-    "webpack-dev-server": "^4.3.1",
+    "webpack-cli": "4.7.0",
+    "webpack-dev-server": "^4.12.0",
     "yargs": "16.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Updated the webpack-dev-server config to be compliant with v4.
Followed [the official migration guide](https://github.com/webpack/webpack-dev-server/blob/master/migration-v4.md).
