### PR TITLE
Fix tabs navigation when using data-binding

### DIFF
--- a/components/tabs/package.json
+++ b/components/tabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coherent-gameface-tabs",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Tabs component for Coherent Labs' Gameface.",
   "main": "index.js",
   "repository": {

--- a/components/tabs/script.js
+++ b/components/tabs/script.js
@@ -43,7 +43,6 @@ class Tabs extends BaseComponent {
             this.tabSlot = this.querySelector('[data-name="tab"]');
             this.panelSlot = this.querySelector('[data-name="panel"]');
 
-            console.log('attach listeners in init callback');
             this.attachEventListeners();
         });
     }
@@ -192,7 +191,7 @@ class Tabs extends BaseComponent {
         // The switch-case will determine which tab should be marked as active
         // depending on the key that was pressed.
         let newTab;
-        switch (event.KEYCODES) {
+        switch (event.keyCode) {
             case KEYCODES.LEFT:
             case KEYCODES.UP:
                 newTab = this.getPrevTab();

--- a/components/tabs/script.js
+++ b/components/tabs/script.js
@@ -39,6 +39,12 @@ class Tabs extends BaseComponent {
         this.setupTemplate(data, () => {
             // render the component
             components.renderOnce(this);
+
+            this.tabSlot = this.querySelector('[data-name="tab"]');
+            this.panelSlot = this.querySelector('[data-name="panel"]');
+
+            console.log('attach listeners in init callback');
+            this.attachEventListeners();
         });
     }
 
@@ -49,11 +55,6 @@ class Tabs extends BaseComponent {
         components.loadResource(this)
             .then(this.init)
             .catch(err => console.error(err));
-
-        this.tabSlot = this.querySelector('[data-name="tab"]');
-        this.panelSlot = this.querySelector('[data-name="panel"]');
-
-        this.attachEventListeners();
     }
 
     /* eslint-enable require-jsdoc */
@@ -63,10 +64,7 @@ class Tabs extends BaseComponent {
      * @param {MouseEvent} event - the event object.
     */
     onClick(event) {
-        // avoid all cases except when the target is a tab heading.
-        if (event.target.tagName.toLowerCase() === 'tab-heading') {
-            this.selectTab(event.target);
-        }
+        this.selectTab(event.currentTarget);
     }
 
     /**
@@ -112,7 +110,12 @@ class Tabs extends BaseComponent {
     */
     attachEventListeners() {
         this.addEventListener('keydown', this.onKeyDown);
-        this.addEventListener('click', this.onClick);
+
+        const tabHeadings = this.querySelectorAll('tab-heading');
+
+        for (const tabHeading of tabHeadings) {
+            tabHeading.addEventListener('click', this.onClick);
+        }
     }
     /**
      * Sets a tab and its corresponding panel in an active state.
@@ -122,7 +125,6 @@ class Tabs extends BaseComponent {
     selectTab(newTab) {
         // Deselect all tabs and hide all panels.
         this.reset();
-
         // Get the panel that the `newTab` is associated with.
         const newPanel = this.getPanelForTab(newTab);
         // If that panel doesn’t exist, abort.


### PR DESCRIPTION

1. Attach event handlers in the init method
2. use currentTarget when handling click
3. Fixed keyboard navigation - we used non-existing property `event.KEYCODES`

[Test plan](https://coherent-labs.atlassian.net/browse/COH-17893)