### PR TITLE
Dependabot now merges its opened PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,4 @@ updates:
     target-branch: "master"
     # Labels on pull requests for security and version updates
     labels:
-      - "npm dependencies check"
+      - "dependencies"

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -9,6 +9,8 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions: write-all
+
 jobs:
   build:
 
@@ -42,16 +44,30 @@ jobs:
      - uses: actions/checkout@v2
        with:
          ref: ${{ github.event.pull_request.head.ref }}
-     - name: Use Node.js ${{ matrix.node-version }}
-       uses: actions/setup-node@v2
+     - name: Dependabot metadata
+       id: metadata
+       uses: dependabot/fetch-metadata@v1
        with:
-        node-version: ${{ matrix.node-version }}
+          GITHUB_TOKEN: "${{secrets.DEPENDABOT}}"
+     - name: Add 'dependencies' label
+       run: gh pr edit "$PR_URL" --add-label "dependencies"
+       env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.DEPENDABOT}}
      - name: Approve a PR
-       if: ${{ needs.build.result == 'success' }}
+       if: ${{ needs.build.result == 'success' && steps.metadata.outputs.update-type != 'version-update:semver-major' }}
        run: gh pr review --approve "$PR_URL"
        env:
          PR_URL: ${{github.event.pull_request.html_url}}
          GITHUB_TOKEN: ${{secrets.DEPENDABOT}}
+     - name: Comment on major updates
+       if: ${{steps.metadata.outputs.update-type == 'version-update:semver-major' }}
+       run: |
+        gh pr comment $PR_URL --body "I'm **not approving** this PR because **it includes a major update of a dependency**"
+        gh pr edit $PR_URL --add-label "requires-manual-qa"
+       env:
+        PR_URL: ${{github.event.pull_request.html_url}}
+        GITHUB_TOKEN: ${{secrets.DEPENDABOT}}
      - name: Merge a PR
        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch' }}
        run: gh pr merge --auto --merge  "$PR_URL"


### PR DESCRIPTION
Also, it will label with 'requires-manual-qa' the PRs that are having major updates and will comment to the PR that it was not approved. Will auto-add 'dependencies' label to the PR if not added because is needed when releasing a new component version the dependencies updates to be marked as 'Dependencies' and not 'Features' to the release notes.


[Task & test plan](https://coherent-labs.atlassian.net/browse/COH-18677)