### PR TITLE
All lift keyboard actions are now executing their callbacks when are triggered

### DIFF
--- a/interaction-manager/package.json
+++ b/interaction-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coherent-gameface-interaction-manager",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Library for the most common UI interactions",
   "main": "dist/interaction-manager.js",
   "module": "esm/interaction-manager.js",

--- a/interaction-manager/src/lib_components/keyboard.js
+++ b/interaction-manager/src/lib_components/keyboard.js
@@ -131,10 +131,9 @@ class Keyboard {
         const registeredKeys = IM.getKeys(keyPressed);
         if (registeredKeys.length === 0) return;
 
-        const registeredKey = registeredKeys.find(key => key.type === 'lift');
-        if (!registeredKey) return;
-
-        this.executeCallback(event, registeredKey);
+        registeredKeys.forEach((key) => {
+            if (key.type === 'lift' && key.keys.indexOf(keyPressed) !== -1) this.executeCallback(event, key);
+        });
     }
 
     /**

--- a/tools/tests/interaction-manager/keyboard/test.js
+++ b/tools/tests/interaction-manager/keyboard/test.js
@@ -15,7 +15,7 @@ describe('Keyboard', () => {
     it('Should register key action', () => {
         interactionManager.keyboard.on({
             keys: singleKey,
-            callback: () => {},
+            callback: () => { },
             type: ['press'],
         });
 
@@ -131,6 +131,40 @@ describe('Keyboard', () => {
         interactionManager.keyboard.off(singleKey);
 
         assert.equal(counter, 1);
+    });
+
+    it('Should execute on key up with type lift for two lift events', () => {
+        const liftedKeys = [];
+        const secondActionKeys = ['B'];
+
+        interactionManager.keyboard.on({
+            keys: singleKey,
+            callback: () => {
+                liftedKeys.push(singleKey[0]);
+            },
+            type: ['lift'],
+        });
+
+        interactionManager.keyboard.on({
+            keys: secondActionKeys,
+            callback: () => {
+                liftedKeys.push(secondActionKeys[0]);
+            },
+            type: ['lift'],
+        });
+
+        singleKey.forEach((key) => {
+            simulateKeyUp(key);
+        });
+
+        secondActionKeys.forEach((key) => {
+            simulateKeyUp(key);
+        });
+
+        interactionManager.keyboard.off(singleKey);
+        interactionManager.keyboard.off(secondActionKeys);
+
+        assert.equal(JSON.stringify(liftedKeys), '["A","B"]');
     });
 
     it('Should execute the same action on two or more types', () => {


### PR DESCRIPTION
- [x] Self-reviewed and fixed any obvious mistakes, TODOs, removed debugging code, logs, etc
- [x] Updated package.json in related components, the library or the cli
- [x] Created tests
- [x] Tested in a browser
- [x] Tested in Gameface

